### PR TITLE
Fix CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2023.12.1
     environment:
       JVM_OPTS: -Xmx3200m
     steps:


### PR DESCRIPTION
Switch to new CircleCI docker images, see explanation on https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Then I picked the latest tag from https://circleci.com/developer/images/image/cimg/android