### PR TITLE
Write tags from folders on microSD card

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
                 android:name=".ui.ReadActivity"
                 android:parentActivityName=".ui.MainActivity"
                 android:exported="false"/>
+        <activity
+                android:name=".ui.UsbFileListActivity"
+                android:parentActivityName=".ui.MainActivity"
+                android:exported="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package de.mw136.tonuino.ui
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -13,7 +14,10 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.os.SystemClock
 import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
+import android.provider.DocumentsContract
 import android.util.Log
 import android.view.View
 import android.widget.TextView
@@ -67,7 +71,7 @@ class MainActivity : NfcIntentActivity() {
         object : StorageManager.StorageVolumeCallback() {
             override fun onStateChanged(volume: android.os.storage.StorageVolume) {
                 if (volume.isRemovable && volume.state == Environment.MEDIA_MOUNTED) {
-                    handleExternalStorageAttached()
+                    handleExternalStorageAttached(volume)
                 }
             }
         }
@@ -133,7 +137,7 @@ class MainActivity : NfcIntentActivity() {
         startUsbFlow(usePersistedUri = false)
     }
 
-    private fun startUsbFlow(usePersistedUri: Boolean) {
+    private fun startUsbFlow(usePersistedUri: Boolean, overrideVolume: StorageVolume? = null) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
 
         val persistedUri =
@@ -152,7 +156,8 @@ class MainActivity : NfcIntentActivity() {
         usedDocumentTreeFallback = false
 
         val removableIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            storageManager?.storageVolumes?.firstOrNull { it.isRemovable }?.createAccessIntent(null)
+            val targetVolume = overrideVolume ?: storageManager?.storageVolumes?.firstOrNull { it.isRemovable }
+            targetVolume?.createAccessIntent(null)
         } else {
             null
         }?.let { withCommonFlags(it) }
@@ -278,20 +283,60 @@ class MainActivity : NfcIntentActivity() {
         }
     }
 
-    private fun handleExternalStorageAttached() {
-        if (!hasMountedRemovableStorage()) return
-        val now = android.os.SystemClock.elapsedRealtime()
+    private fun handleExternalStorageAttached(volume: StorageVolume? = null) {
+        val mountedVolume = volume ?: getMountedRemovableVolume() ?: return
+        val now = SystemClock.elapsedRealtime()
         if (now - lastUsbAttachHandledAt < 1_000) return
         lastUsbAttachHandledAt = now
-        startUsbFlow(usePersistedUri = true)
+
+        val persistedUri = usbPermissionStore.getPersistedUriIfReadable(contentResolver)
+        val persistedVolumeId = persistedUri?.let { uri ->
+            DocumentsContract.getTreeDocumentId(uri).substringBefore(":")
+        }
+        val attachedVolumeId = mountedVolume.uuid ?: if (mountedVolume.isPrimary) "primary" else null
+
+        if (persistedUri != null && attachedVolumeId != null && persistedVolumeId != null && attachedVolumeId != persistedVolumeId) {
+            showSwitchVolumeDialog(mountedVolume)
+            return
+        }
+
+        startUsbFlow(usePersistedUri = true, overrideVolume = mountedVolume)
     }
 
     private fun hasMountedRemovableStorage(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return false
-        val storageManager = getSystemService(StorageManager::class.java) ?: return false
-        return storageManager.storageVolumes.any { volume ->
+        return getMountedRemovableVolume() != null
+    }
+
+    private fun getMountedRemovableVolume(): StorageVolume? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null
+        val storageManager = getSystemService(StorageManager::class.java) ?: return null
+        return storageManager.storageVolumes.firstOrNull { volume ->
             volume.isRemovable && volume.state == Environment.MEDIA_MOUNTED
         }
+    }
+
+    private fun showSwitchVolumeDialog(volume: StorageVolume) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.main_usb_new_drive_title)
+            .setMessage(R.string.main_usb_new_drive_message)
+            .setPositiveButton(R.string.main_usb_new_drive_use) { _, _ ->
+                launchPickerForVolume(volume)
+            }
+            .setNegativeButton(R.string.main_usb_new_drive_keep) { dialog, _ -> dialog.dismiss() }
+            .show()
+    }
+
+    private fun launchPickerForVolume(volume: StorageVolume) {
+        usedDocumentTreeFallback = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val intent = volume.createAccessIntent(null)?.let { withCommonFlags(it) }
+            if (intent != null) {
+                usbStoragePicker.launch(intent)
+                return
+            }
+        }
+
+        usbStoragePicker.launch(buildDocumentTreeIntent())
     }
 
     private fun registerReceiverCompat(
@@ -311,7 +356,8 @@ class MainActivity : NfcIntentActivity() {
             registerReceiverCompat(usbAttachReceiver, filter)
             true
         } catch (e: SecurityException) {
-            Log.w(TAG, "Could not register USB receiver for action ${filter.actionsIterator().asSequence().joinToString()}: ${e.message}")
+            val actions = filter.actionsIterator().asSequence().joinToString()
+            Log.w(TAG, "Could not register USB receiver for action $actions: ${e.message}")
             false
         }
     }

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.storage.StorageVolume
 import android.provider.DocumentsContract
 import android.util.Log
 import android.view.View
+import android.widget.Button
 import android.widget.TextView
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -127,6 +128,8 @@ class MainActivity : NfcIntentActivity() {
         if (BuildConfig.DEBUG) {
             enabledContainer.visibility = View.VISIBLE
         }
+
+        updateUsbListButtonState()
     }
 
     fun listUsbFiles(@Suppress("UNUSED_PARAMETER") view: View) {
@@ -139,7 +142,9 @@ class MainActivity : NfcIntentActivity() {
 
     private fun startUsbFlow(usePersistedUri: Boolean, overrideVolume: StorageVolume? = null) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
+        usedDocumentTreeFallback = false
 
+        val hadSavedUri = usbPermissionStore.hasSavedUri()
         val persistedUri =
             if (usePersistedUri) usbPermissionStore.getPersistedUriIfReadable(contentResolver) else null
         if (usePersistedUri) {
@@ -147,13 +152,22 @@ class MainActivity : NfcIntentActivity() {
                 statusView.text = getString(R.string.main_usb_using_saved_access)
                 proceedWithUsbUri(persistedUri, statusView, rememberSelection = false)
                 return
-            } else if (usbPermissionStore.hasSavedUri()) {
+            }
+
+            if (overrideVolume == null) {
+                statusView.text = if (hadSavedUri) {
+                    getString(R.string.main_usb_saved_access_invalid)
+                } else {
+                    getString(R.string.main_usb_no_saved_location)
+                }
+                updateUsbListButtonState()
+                return
+            } else if (hadSavedUri) {
                 statusView.text = getString(R.string.main_usb_saved_access_invalid)
             }
         }
 
         val storageManager = getSystemService(StorageManager::class.java)
-        usedDocumentTreeFallback = false
 
         val removableIntent = buildVolumeRootPickerIntent(
             overrideVolume ?: storageManager?.storageVolumes?.firstOrNull { it.isRemovable }
@@ -209,9 +223,11 @@ class MainActivity : NfcIntentActivity() {
         if (root == null || !root.canRead()) {
             statusView.text = getString(R.string.main_usb_open_failed)
             usbPermissionStore.clear()
+            updateUsbListButtonState()
             return
         }
 
+        updateUsbListButtonState()
         statusView.text = getString(R.string.usb_list_loading)
         Log.i(TAG, "Opening USB file list for uri=$uri")
         startActivity(Intent(this, UsbFileListActivity::class.java).apply {
@@ -227,6 +243,26 @@ class MainActivity : NfcIntentActivity() {
         addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
         addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
         addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
+    }
+
+    private fun updateUsbListButtonState() {
+        val usbListButton = findViewById<Button>(R.id.usb_list_button)
+        val statusView = findViewById<TextView>(R.id.usb_result_text)
+        val hadSavedUri = usbPermissionStore.hasSavedUri()
+        val persistedUri = usbPermissionStore.getPersistedUriIfReadable(contentResolver)
+        val enabled = persistedUri != null
+
+        usbListButton.isEnabled = enabled
+        usbListButton.alpha = if (enabled) 1f else 0.5f
+
+        if (!enabled && statusView.text.isNullOrBlank()) {
+            val message = if (hadSavedUri) {
+                getString(R.string.main_usb_saved_access_invalid)
+            } else {
+                getString(R.string.main_usb_no_saved_location)
+            }
+            statusView.text = message
+        }
     }
 
     fun showWriteActivity(view: View) {

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -52,6 +52,8 @@ class MainActivity : NfcIntentActivity() {
         override fun onReceive(context: Context?, intent: Intent?) {
             when (intent?.action) {
                 Intent.ACTION_MEDIA_MOUNTED -> handleExternalStorageAttached()
+                Intent.ACTION_MEDIA_UNMOUNTED, Intent.ACTION_MEDIA_REMOVED, Intent.ACTION_MEDIA_EJECT ->
+                    handleExternalStorageDetached()
                 UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
                     val device: UsbDevice? = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
                     val isMassStorage = device?.let {
@@ -64,6 +66,7 @@ class MainActivity : NfcIntentActivity() {
                         handleExternalStorageAttached()
                     }
                 }
+                UsbManager.ACTION_USB_DEVICE_DETACHED -> handleExternalStorageDetached()
             }
         }
     }
@@ -71,8 +74,12 @@ class MainActivity : NfcIntentActivity() {
     private val storageVolumeCallback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         object : StorageManager.StorageVolumeCallback() {
             override fun onStateChanged(volume: android.os.storage.StorageVolume) {
-                if (volume.isRemovable && volume.state == Environment.MEDIA_MOUNTED) {
-                    handleExternalStorageAttached(volume)
+                if (volume.isRemovable) {
+                    if (volume.state == Environment.MEDIA_MOUNTED) {
+                        handleExternalStorageAttached(volume)
+                    } else {
+                        handleExternalStorageDetached()
+                    }
                 }
             }
         }
@@ -283,12 +290,19 @@ class MainActivity : NfcIntentActivity() {
         if (!mediaReceiverRegistered) {
             val mediaFilter = IntentFilter(Intent.ACTION_MEDIA_MOUNTED).apply {
                 addDataScheme("file")
+                addAction(Intent.ACTION_MEDIA_UNMOUNTED)
+                addAction(Intent.ACTION_MEDIA_REMOVED)
+                addAction(Intent.ACTION_MEDIA_EJECT)
             }
             mediaReceiverRegistered = registerReceiverSafely(mediaFilter)
         }
 
         if (!usbAttachedReceiverRegistered) {
-            usbAttachedReceiverRegistered = registerReceiverSafely(IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED))
+            val usbFilter = IntentFilter().apply {
+                addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED)
+                addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
+            }
+            usbAttachedReceiverRegistered = registerReceiverSafely(usbFilter)
         }
 
         if (!storageVolumeCallbackRegistered && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -334,6 +348,10 @@ class MainActivity : NfcIntentActivity() {
         }
 
         startUsbFlow(usePersistedUri = true, overrideVolume = mountedVolume)
+    }
+
+    private fun handleExternalStorageDetached() {
+        updateUsbListButtonState()
     }
 
     private fun hasMountedRemovableStorage(): Boolean {

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -1,11 +1,17 @@
 package de.mw136.tonuino.ui
 
+import android.app.Activity
 import android.content.Intent
 import android.nfc.Tag
+import android.os.Build
 import android.os.Bundle
+import android.os.storage.StorageManager
 import android.util.Log
 import android.view.View
 import android.widget.TextView
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.documentfile.provider.DocumentFile
 import de.mw136.tonuino.BuildConfig
 import de.mw136.tonuino.R
 import de.mw136.tonuino.byteArrayToHex
@@ -16,6 +22,11 @@ import de.mw136.tonuino.ui.enter.TagData
 @ExperimentalUnsignedTypes
 class MainActivity : NfcIntentActivity() {
     override val TAG = "MainActivity"
+
+    private val usbStoragePicker =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            handleUsbStorageResult(result)
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,6 +66,84 @@ class MainActivity : NfcIntentActivity() {
         if (BuildConfig.DEBUG) {
             enabledContainer.visibility = View.VISIBLE
         }
+    }
+
+    fun listUsbFiles(@Suppress("UNUSED_PARAMETER") view: View) {
+        val statusView = findViewById<TextView>(R.id.usb_result_text)
+        val storageManager = getSystemService(StorageManager::class.java)
+
+        val removableIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            storageManager?.storageVolumes?.firstOrNull { it.isRemovable }?.createAccessIntent(null)
+        } else {
+            null
+        }
+
+        if (removableIntent != null) {
+            usbStoragePicker.launch(removableIntent)
+            return
+        }
+
+        statusView.text = getString(R.string.main_usb_not_found)
+        usbStoragePicker.launch(Intent(Intent.ACTION_OPEN_DOCUMENT_TREE))
+    }
+
+    private fun handleUsbStorageResult(result: ActivityResult) {
+        val statusView = findViewById<TextView>(R.id.usb_result_text)
+
+        if (result.resultCode != Activity.RESULT_OK) {
+            statusView.text = getString(R.string.main_usb_picker_cancelled)
+            return
+        }
+
+        val resultData = result.data
+        val uri = resultData?.data
+        if (uri == null) {
+            statusView.text = getString(R.string.main_usb_missing_uri)
+            return
+        }
+
+        val takeFlags =
+            (resultData.flags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION))
+        try {
+            contentResolver.takePersistableUriPermission(uri, takeFlags)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Could not persist USB permission: ${e.message}")
+        }
+
+        val root = DocumentFile.fromTreeUri(this, uri)
+        if (root == null) {
+            statusView.text = getString(R.string.main_usb_open_failed)
+            return
+        }
+
+        val files = listFilesRecursively(root)
+        if (files.isEmpty()) {
+            statusView.text = getString(R.string.main_usb_no_files)
+            return
+        }
+
+        val message = buildString {
+            appendLine(getString(R.string.main_usb_listing_prefix))
+            files.forEach { appendLine(it) }
+        }.trimEnd()
+
+        statusView.text = message
+        Log.i(TAG, "Files on USB drive:\n$message")
+    }
+
+    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
+        val collected = mutableListOf<String>()
+        for (child in node.listFiles()) {
+            val name = child.name ?: "(unnamed)"
+            val path = if (prefix.isEmpty()) name else "$prefix/$name"
+            if (child.isDirectory) {
+                collected.add("$path/")
+                collected.addAll(listFilesRecursively(child, path))
+            } else {
+                collected.add(path)
+            }
+        }
+        return collected
     }
 
     fun showWriteActivity(view: View) {

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -115,21 +115,6 @@ class MainActivity : NfcIntentActivity() {
         proceedWithUsbUri(uri, statusView)
     }
 
-    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
-        val collected = mutableListOf<String>()
-        for (child in node.listFiles()) {
-            val name = child.name ?: "(unnamed)"
-            val path = if (prefix.isEmpty()) name else "$prefix/$name"
-            if (child.isDirectory) {
-                collected.add("$path/")
-                collected.addAll(listFilesRecursively(child, path))
-            } else {
-                collected.add(path)
-            }
-        }
-        return collected
-    }
-
     private fun proceedWithUsbUri(uri: android.net.Uri, statusView: TextView) {
         val takeFlags =
             Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
@@ -145,19 +130,11 @@ class MainActivity : NfcIntentActivity() {
             return
         }
 
-        val files = listFilesRecursively(root)
-        if (files.isEmpty()) {
-            statusView.text = getString(R.string.main_usb_no_files)
-            return
-        }
-
-        val message = buildString {
-            appendLine(getString(R.string.main_usb_listing_prefix))
-            files.forEach { appendLine(it) }
-        }.trimEnd()
-
-        statusView.text = message
-        Log.i(TAG, "Files on USB drive:\n$message")
+        statusView.text = getString(R.string.usb_list_loading)
+        Log.i(TAG, "Opening USB file list for uri=$uri")
+        startActivity(Intent(this, UsbFileListActivity::class.java).apply {
+            data = uri
+        })
     }
 
     private fun buildDocumentTreeIntent(): Intent =

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -1,11 +1,18 @@
 package de.mw136.tonuino.ui
 
 import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
 import android.nfc.Tag
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.os.storage.StorageManager
 import android.util.Log
 import android.view.View
@@ -26,15 +33,61 @@ class MainActivity : NfcIntentActivity() {
 
     private var usedDocumentTreeFallback = false
     private val usbPermissionStore by lazy { UsbPermissionStore(this) }
+    private var mediaReceiverRegistered = false
+    private var usbAttachedReceiverRegistered = false
+    private var storageVolumeCallbackRegistered = false
+    private var lastUsbAttachHandledAt = 0L
 
     private val usbStoragePicker =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             handleUsbStorageResult(result)
         }
 
+    private val usbAttachReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_MEDIA_MOUNTED -> handleExternalStorageAttached()
+                UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
+                    val device: UsbDevice? = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                    val isMassStorage = device?.let {
+                        (0 until it.interfaceCount).any { index ->
+                            it.getInterface(index).interfaceClass == UsbConstants.USB_CLASS_MASS_STORAGE
+                        }
+                    } ?: false
+
+                    if (isMassStorage) {
+                        handleExternalStorageAttached()
+                    }
+                }
+            }
+        }
+    }
+
+    private val storageVolumeCallback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        object : StorageManager.StorageVolumeCallback() {
+            override fun onStateChanged(volume: android.os.storage.StorageVolume) {
+                if (volume.isRemovable && volume.state == Environment.MEDIA_MOUNTED) {
+                    handleExternalStorageAttached()
+                }
+            }
+        }
+    } else {
+        null
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        registerUsbAttachReceiver()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        unregisterUsbAttachReceiver()
     }
 
     override fun onResume() {
@@ -186,6 +239,89 @@ class MainActivity : NfcIntentActivity() {
     @Suppress("UNUSED_PARAMETER")
     fun openNfcSettings(view: View) {
         startActivity(Intent(android.provider.Settings.ACTION_NFC_SETTINGS))
+    }
+
+    private fun registerUsbAttachReceiver() {
+        if (!mediaReceiverRegistered) {
+            val mediaFilter = IntentFilter(Intent.ACTION_MEDIA_MOUNTED).apply {
+                addDataScheme("file")
+            }
+            mediaReceiverRegistered = registerReceiverSafely(mediaFilter)
+        }
+
+        if (!usbAttachedReceiverRegistered) {
+            usbAttachedReceiverRegistered = registerReceiverSafely(IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED))
+        }
+
+        if (!storageVolumeCallbackRegistered && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            storageVolumeCallback?.let { callback ->
+                getSystemService(StorageManager::class.java)?.registerStorageVolumeCallback(mainExecutor, callback)
+                storageVolumeCallbackRegistered = true
+            }
+        }
+    }
+
+    private fun unregisterUsbAttachReceiver() {
+        if (mediaReceiverRegistered) {
+            unregisterReceiverSafely()
+            mediaReceiverRegistered = false
+        }
+        if (usbAttachedReceiverRegistered) {
+            unregisterReceiverSafely()
+            usbAttachedReceiverRegistered = false
+        }
+        if (storageVolumeCallbackRegistered && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            storageVolumeCallback?.let { callback ->
+                getSystemService(StorageManager::class.java)?.unregisterStorageVolumeCallback(callback)
+            }
+            storageVolumeCallbackRegistered = false
+        }
+    }
+
+    private fun handleExternalStorageAttached() {
+        if (!hasMountedRemovableStorage()) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (now - lastUsbAttachHandledAt < 1_000) return
+        lastUsbAttachHandledAt = now
+        startUsbFlow(usePersistedUri = true)
+    }
+
+    private fun hasMountedRemovableStorage(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return false
+        val storageManager = getSystemService(StorageManager::class.java) ?: return false
+        return storageManager.storageVolumes.any { volume ->
+            volume.isRemovable && volume.state == Environment.MEDIA_MOUNTED
+        }
+    }
+
+    private fun registerReceiverCompat(
+        receiver: BroadcastReceiver,
+        filter: IntentFilter,
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION")
+            registerReceiver(receiver, filter)
+        }
+    }
+
+    private fun registerReceiverSafely(filter: IntentFilter): Boolean {
+        return try {
+            registerReceiverCompat(usbAttachReceiver, filter)
+            true
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Could not register USB receiver for action ${filter.actionsIterator().asSequence().joinToString()}: ${e.message}")
+            false
+        }
+    }
+
+    private fun unregisterReceiverSafely() {
+        try {
+            unregisterReceiver(usbAttachReceiver)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "USB receiver already unregistered: ${e.message}")
+        }
     }
 
     override fun onNfcTag(tag: Tag) {

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -155,12 +155,9 @@ class MainActivity : NfcIntentActivity() {
         val storageManager = getSystemService(StorageManager::class.java)
         usedDocumentTreeFallback = false
 
-        val removableIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val targetVolume = overrideVolume ?: storageManager?.storageVolumes?.firstOrNull { it.isRemovable }
-            targetVolume?.createAccessIntent(null)
-        } else {
-            null
-        }?.let { withCommonFlags(it) }
+        val removableIntent = buildVolumeRootPickerIntent(
+            overrideVolume ?: storageManager?.storageVolumes?.firstOrNull { it.isRemovable }
+        )
 
         if (removableIntent != null) {
             usbStoragePicker.launch(removableIntent)
@@ -328,15 +325,31 @@ class MainActivity : NfcIntentActivity() {
 
     private fun launchPickerForVolume(volume: StorageVolume) {
         usedDocumentTreeFallback = false
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val intent = volume.createAccessIntent(null)?.let { withCommonFlags(it) }
-            if (intent != null) {
-                usbStoragePicker.launch(intent)
-                return
+        val intent = buildVolumeRootPickerIntent(volume)
+        if (intent != null) {
+            usbStoragePicker.launch(intent)
+        } else {
+            usbStoragePicker.launch(buildDocumentTreeIntent())
+        }
+    }
+
+    private fun buildVolumeRootPickerIntent(volume: StorageVolume?): Intent? {
+        if (volume == null) return null
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val intent = volume.createOpenDocumentTreeIntent() ?: return null
+            val initialUri = intent.getParcelableExtra<Uri>(DocumentsContract.EXTRA_INITIAL_URI)
+            if (initialUri != null) {
+                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri)
             }
+            return withCommonFlags(intent)
         }
 
-        usbStoragePicker.launch(buildDocumentTreeIntent())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return volume.createAccessIntent(null)?.let { withCommonFlags(it) }
+        }
+
+        return null
     }
 
     private fun registerReceiverCompat(

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -73,15 +73,26 @@ class MainActivity : NfcIntentActivity() {
     }
 
     fun listUsbFiles(@Suppress("UNUSED_PARAMETER") view: View) {
+        startUsbFlow(usePersistedUri = true)
+    }
+
+    fun pickUsbLocation(@Suppress("UNUSED_PARAMETER") view: View) {
+        startUsbFlow(usePersistedUri = false)
+    }
+
+    private fun startUsbFlow(usePersistedUri: Boolean) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
 
-        val persistedUri = usbPermissionStore.getPersistedUriIfReadable(contentResolver)
-        if (persistedUri != null) {
-            statusView.text = getString(R.string.main_usb_using_saved_access)
-            proceedWithUsbUri(persistedUri, statusView, rememberSelection = false)
-            return
-        } else if (usbPermissionStore.hasSavedUri()) {
-            statusView.text = getString(R.string.main_usb_saved_access_invalid)
+        val persistedUri =
+            if (usePersistedUri) usbPermissionStore.getPersistedUriIfReadable(contentResolver) else null
+        if (usePersistedUri) {
+            if (persistedUri != null) {
+                statusView.text = getString(R.string.main_usb_using_saved_access)
+                proceedWithUsbUri(persistedUri, statusView, rememberSelection = false)
+                return
+            } else if (usbPermissionStore.hasSavedUri()) {
+                statusView.text = getString(R.string.main_usb_saved_access_invalid)
+            }
         }
 
         val storageManager = getSystemService(StorageManager::class.java)

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package de.mw136.tonuino.ui
 import android.app.Activity
 import android.content.Intent
 import android.nfc.Tag
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.storage.StorageManager
@@ -24,6 +25,7 @@ class MainActivity : NfcIntentActivity() {
     override val TAG = "MainActivity"
 
     private var usedDocumentTreeFallback = false
+    private val usbPermissionStore by lazy { UsbPermissionStore(this) }
 
     private val usbStoragePicker =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -72,6 +74,16 @@ class MainActivity : NfcIntentActivity() {
 
     fun listUsbFiles(@Suppress("UNUSED_PARAMETER") view: View) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
+
+        val persistedUri = usbPermissionStore.getPersistedUriIfReadable(contentResolver)
+        if (persistedUri != null) {
+            statusView.text = getString(R.string.main_usb_using_saved_access)
+            proceedWithUsbUri(persistedUri, statusView, rememberSelection = false)
+            return
+        } else if (usbPermissionStore.hasSavedUri()) {
+            statusView.text = getString(R.string.main_usb_saved_access_invalid)
+        }
+
         val storageManager = getSystemService(StorageManager::class.java)
         usedDocumentTreeFallback = false
 
@@ -107,26 +119,30 @@ class MainActivity : NfcIntentActivity() {
             if (uri == null) {
                 statusView.text = getString(R.string.main_usb_picker_cancelled)
             } else {
-                proceedWithUsbUri(uri, statusView)
+                proceedWithUsbUri(uri, statusView, rememberSelection = false)
             }
             return
         }
 
-        proceedWithUsbUri(uri, statusView)
+        proceedWithUsbUri(uri, statusView, rememberSelection = true)
     }
 
-    private fun proceedWithUsbUri(uri: android.net.Uri, statusView: TextView) {
-        val takeFlags =
-            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-        try {
-            contentResolver.takePersistableUriPermission(uri, takeFlags)
-        } catch (e: SecurityException) {
-            Log.w(TAG, "Could not persist USB permission: ${e.message}")
+    private fun proceedWithUsbUri(uri: Uri, statusView: TextView, rememberSelection: Boolean) {
+        if (rememberSelection) {
+            val takeFlags =
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            try {
+                contentResolver.takePersistableUriPermission(uri, takeFlags)
+                usbPermissionStore.rememberUri(uri)
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Could not persist USB permission: ${e.message}")
+            }
         }
 
         val root = DocumentFile.fromTreeUri(this, uri)
-        if (root == null) {
+        if (root == null || !root.canRead()) {
             statusView.text = getString(R.string.main_usb_open_failed)
+            usbPermissionStore.clear()
             return
         }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -351,6 +351,7 @@ class MainActivity : NfcIntentActivity() {
     }
 
     private fun handleExternalStorageDetached() {
+        UsbFolderCache.clear()
         updateUsbListButtonState()
     }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/MainActivity.kt
@@ -23,6 +23,8 @@ import de.mw136.tonuino.ui.enter.TagData
 class MainActivity : NfcIntentActivity() {
     override val TAG = "MainActivity"
 
+    private var usedDocumentTreeFallback = false
+
     private val usbStoragePicker =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             handleUsbStorageResult(result)
@@ -71,12 +73,13 @@ class MainActivity : NfcIntentActivity() {
     fun listUsbFiles(@Suppress("UNUSED_PARAMETER") view: View) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
         val storageManager = getSystemService(StorageManager::class.java)
+        usedDocumentTreeFallback = false
 
         val removableIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             storageManager?.storageVolumes?.firstOrNull { it.isRemovable }?.createAccessIntent(null)
         } else {
             null
-        }
+        }?.let { withCommonFlags(it) }
 
         if (removableIntent != null) {
             usbStoragePicker.launch(removableIntent)
@@ -84,26 +87,52 @@ class MainActivity : NfcIntentActivity() {
         }
 
         statusView.text = getString(R.string.main_usb_not_found)
-        usbStoragePicker.launch(Intent(Intent.ACTION_OPEN_DOCUMENT_TREE))
+        usedDocumentTreeFallback = true
+        usbStoragePicker.launch(buildDocumentTreeIntent())
     }
 
     private fun handleUsbStorageResult(result: ActivityResult) {
         val statusView = findViewById<TextView>(R.id.usb_result_text)
-
-        if (result.resultCode != Activity.RESULT_OK) {
-            statusView.text = getString(R.string.main_usb_picker_cancelled)
-            return
-        }
-
         val resultData = result.data
         val uri = resultData?.data
-        if (uri == null) {
-            statusView.text = getString(R.string.main_usb_missing_uri)
+
+        if (result.resultCode != Activity.RESULT_OK || uri == null) {
+            if (!usedDocumentTreeFallback) {
+                statusView.text = getString(R.string.main_usb_not_found)
+                usedDocumentTreeFallback = true
+                usbStoragePicker.launch(buildDocumentTreeIntent())
+                return
+            }
+
+            if (uri == null) {
+                statusView.text = getString(R.string.main_usb_picker_cancelled)
+            } else {
+                proceedWithUsbUri(uri, statusView)
+            }
             return
         }
 
+        proceedWithUsbUri(uri, statusView)
+    }
+
+    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
+        val collected = mutableListOf<String>()
+        for (child in node.listFiles()) {
+            val name = child.name ?: "(unnamed)"
+            val path = if (prefix.isEmpty()) name else "$prefix/$name"
+            if (child.isDirectory) {
+                collected.add("$path/")
+                collected.addAll(listFilesRecursively(child, path))
+            } else {
+                collected.add(path)
+            }
+        }
+        return collected
+    }
+
+    private fun proceedWithUsbUri(uri: android.net.Uri, statusView: TextView) {
         val takeFlags =
-            (resultData.flags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION))
+            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         try {
             contentResolver.takePersistableUriPermission(uri, takeFlags)
         } catch (e: SecurityException) {
@@ -131,19 +160,14 @@ class MainActivity : NfcIntentActivity() {
         Log.i(TAG, "Files on USB drive:\n$message")
     }
 
-    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
-        val collected = mutableListOf<String>()
-        for (child in node.listFiles()) {
-            val name = child.name ?: "(unnamed)"
-            val path = if (prefix.isEmpty()) name else "$prefix/$name"
-            if (child.isDirectory) {
-                collected.add("$path/")
-                collected.addAll(listFilesRecursively(child, path))
-            } else {
-                collected.add(path)
-            }
-        }
-        return collected
+    private fun buildDocumentTreeIntent(): Intent =
+        withCommonFlags(Intent(Intent.ACTION_OPEN_DOCUMENT_TREE))
+
+    private fun withCommonFlags(intent: Intent): Intent = intent.apply {
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+        addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
     }
 
     fun showWriteActivity(view: View) {

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,8 +1,10 @@
 package de.mw136.tonuino.ui
 
+import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.os.Bundle
 import android.view.View
+import android.widget.ImageView
 import android.widget.TableLayout
 import android.widget.TableRow
 import android.widget.TextView
@@ -57,8 +59,20 @@ class UsbFileListActivity : AppCompatActivity() {
 
     private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
         // Keep the header row defined in XML, append folder rows below
+        val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
         for (summary in folders) {
             val row = TableRow(this)
+            val artView = ImageView(this).apply {
+                layoutParams = TableRow.LayoutParams(albumArtSize, albumArtSize)
+                adjustViewBounds = true
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                val artBytes = summary.albumArt
+                if (artBytes != null) {
+                    BitmapFactory.decodeByteArray(artBytes, 0, artBytes.size)?.let { bitmap ->
+                        setImageBitmap(bitmap)
+                    }
+                }
+            }
             val nameView = TextView(this).apply {
                 text = summary.name
                 layoutParams = TableRow.LayoutParams(
@@ -74,6 +88,7 @@ class UsbFileListActivity : AppCompatActivity() {
                 text = summary.album ?: getString(R.string.usb_list_unknown_album)
                 layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
             }
+            row.addView(artView)
             row.addView(nameView)
             row.addView(artistView)
             row.addView(albumView)

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -199,19 +199,16 @@ class UsbFileListActivity : AppCompatActivity() {
                 }
             } else {
                 val isEmpty = item.trackCount == 0
-                trackCountView.visibility = if (isEmpty) View.GONE else View.VISIBLE
-                val trackLabel = if (isEmpty) {
-                    getString(R.string.usb_list_empty_folder)
-                } else {
-                    getString(R.string.usb_list_track_count, item.trackCount)
-                }
-                titleView.text = getString(R.string.usb_folder_title_format, item.name, trackLabel)
                 if (isEmpty) {
+                    titleView.text = getString(R.string.usb_folder_title_format, item.name, getString(R.string.usb_list_empty_folder))
                     artistView.text = ""
                     artistView.visibility = View.GONE
+                    trackCountView.visibility = View.GONE
                 } else {
+                    titleView.text = getString(R.string.usb_folder_title_format, item.name, getString(R.string.usb_list_mixed_album))
                     artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
                     artistView.visibility = View.VISIBLE
+                    trackCountView.visibility = View.VISIBLE
                     trackCountView.text = getString(R.string.usb_list_track_count, item.trackCount)
                 }
                 artView.setImageDrawable(null)

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -9,17 +9,18 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.util.TypedValue
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
 import android.widget.ImageView
+import android.widget.ListView
 import android.widget.ProgressBar
-import android.widget.TableLayout
-import android.widget.TableRow
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.documentfile.provider.DocumentFile
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
+import androidx.documentfile.provider.DocumentFile
 import de.mw136.tonuino.R
 import de.mw136.tonuino.nfc.NfcIntentActivity
 import de.mw136.tonuino.ui.enter.TagData
@@ -27,7 +28,6 @@ import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.ExperimentalUnsignedTypes
-import kotlin.math.roundToInt
 
 @ExperimentalUnsignedTypes
 class UsbFileListActivity : AppCompatActivity() {
@@ -48,30 +48,30 @@ class UsbFileListActivity : AppCompatActivity() {
         supportActionBar?.title = getString(R.string.usb_list_title)
 
         val statusView = findViewById<TextView>(R.id.usb_file_list_status)
-        val table = findViewById<TableLayout>(R.id.usb_file_table)
+        val listView = findViewById<ListView>(R.id.usb_folder_list)
 
         val uri = intent?.data
         if (uri == null) {
             statusView.text = getString(R.string.usb_list_no_uri)
-            table.visibility = View.GONE
+            listView.visibility = View.GONE
             return
         }
 
         val root = DocumentFile.fromTreeUri(this, uri)
         if (root == null) {
             statusView.text = getString(R.string.usb_list_error)
-            table.visibility = View.GONE
+            listView.visibility = View.GONE
             return
         }
 
         val cachedFolders = UsbFolderCache.getCachedFolders(this, uri)
         if (cachedFolders != null) {
-            showFolderSummaries(statusView, table, cachedFolders)
+            showFolderSummaries(statusView, listView, cachedFolders)
             return
         }
 
         statusView.text = getString(R.string.usb_list_loading)
-        scanFoldersAsync(root, uri, table, statusView)
+        scanFoldersAsync(root, uri, listView, statusView)
     }
 
     override fun onDestroy() {
@@ -90,104 +90,6 @@ class UsbFileListActivity : AppCompatActivity() {
         return if (numeric in selectableFolderRange) numeric else null
     }
 
-    private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
-        // Keep the header row defined in XML, append folder rows below
-        while (table.childCount > 1) {
-            table.removeViewAt(1)
-        }
-        val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
-        val verticalSpacing = (albumArtSize * 0.2f).roundToInt().coerceAtLeast(1)
-        val horizontalSpacing = resources.getDimensionPixelSize(R.dimen.usb_table_horizontal_spacing)
-        val halfHorizontalSpacing = (horizontalSpacing / 2f).roundToInt().coerceAtLeast(0)
-        val accentColor = ContextCompat.getColor(this, R.color.colorAccent)
-        val selectableBackground = selectableItemBackgroundRes()
-
-        applyHorizontalSpacingToHeader(table, halfHorizontalSpacing)
-        for (summary in folders) {
-            val row = TableRow(this).apply {
-                isClickable = true
-                isFocusable = true
-                setBackgroundResource(selectableBackground)
-                setOnClickListener { launchWriteActivity(summary.name) }
-            }
-            val artView = ImageView(this).apply {
-                layoutParams = TableRow.LayoutParams(albumArtSize, albumArtSize).apply {
-                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
-                }
-                adjustViewBounds = true
-                scaleType = ImageView.ScaleType.CENTER_CROP
-                val artBytes = summary.albumArt
-                if (artBytes != null) {
-                    BitmapFactory.decodeByteArray(artBytes, 0, artBytes.size)?.let { bitmap ->
-                        setImageBitmap(bitmap)
-                    }
-                }
-            }
-            val nameView = TextView(this).apply {
-                text = summary.name
-                layoutParams = TableRow.LayoutParams(
-                    TableRow.LayoutParams.WRAP_CONTENT,
-                    TableRow.LayoutParams.WRAP_CONTENT
-                ).apply { setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0) }
-            }
-            val artistView = TextView(this).apply {
-                text = summary.artist ?: getString(R.string.usb_list_unknown_artist)
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f).apply {
-                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
-                }
-            }
-            val albumView = TextView(this).apply {
-                text = summary.album ?: getString(R.string.usb_list_unknown_album)
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f).apply {
-                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
-                }
-            }
-            val chevronView = ImageView(this).apply {
-                setImageResource(R.drawable.ic_chevron_right_24)
-                ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(accentColor))
-                layoutParams = TableRow.LayoutParams(
-                    TableRow.LayoutParams.WRAP_CONTENT,
-                    TableRow.LayoutParams.WRAP_CONTENT
-                ).apply { setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0) }
-                contentDescription = getString(R.string.usb_list_row_action_hint)
-            }
-            row.addView(nameView)
-            row.addView(artView)
-            row.addView(artistView)
-            row.addView(albumView)
-            row.addView(chevronView)
-
-            val rowLayoutParams = TableLayout.LayoutParams(
-                TableLayout.LayoutParams.MATCH_PARENT,
-                TableLayout.LayoutParams.WRAP_CONTENT
-            ).apply {
-                setMargins(0, verticalSpacing, 0, verticalSpacing)
-            }
-            table.addView(row, rowLayoutParams)
-        }
-    }
-
-    private fun applyHorizontalSpacingToHeader(table: TableLayout, halfSpacing: Int) {
-        val headerRow = table.getChildAt(0) as? TableRow ?: return
-        for (i in 0 until headerRow.childCount) {
-            val child = headerRow.getChildAt(i)
-            val existingParams = child.layoutParams
-            val params = if (existingParams is TableRow.LayoutParams) {
-                existingParams
-            } else {
-                TableRow.LayoutParams(existingParams)
-            }
-            params.setMargins(halfSpacing, params.topMargin, halfSpacing, params.bottomMargin)
-            child.layoutParams = params
-        }
-    }
-
-    private fun selectableItemBackgroundRes(): Int {
-        val outValue = TypedValue()
-        theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
-        return outValue.resourceId
-    }
-
     private fun launchWriteActivity(folderName: String) {
         val folderNumber = parseSelectableFolderNumber(folderName) ?: return
         val tagData = TagData().apply { setFolder(folderNumber.toUByte()) }
@@ -199,7 +101,7 @@ class UsbFileListActivity : AppCompatActivity() {
     private fun scanFoldersAsync(
         root: DocumentFile,
         uri: Uri,
-        table: TableLayout,
+        listView: ListView,
         statusView: TextView
     ) {
         showProgressDialog()
@@ -217,23 +119,72 @@ class UsbFileListActivity : AppCompatActivity() {
             mainHandler.post {
                 if (isFinishing || isDestroyed) return@post
                 dismissProgressDialog()
-                showFolderSummaries(statusView, table, summaries)
+                showFolderSummaries(statusView, listView, summaries)
             }
         }
     }
 
     private fun showFolderSummaries(
         statusView: TextView,
-        table: TableLayout,
+        listView: ListView,
         folders: List<FolderSummary>
     ) {
         if (folders.isEmpty()) {
             statusView.text = getString(R.string.usb_list_no_folders)
-            table.visibility = View.GONE
+            listView.visibility = View.GONE
         } else {
             statusView.visibility = View.GONE
-            table.visibility = View.VISIBLE
-            populateTable(table, folders)
+            listView.visibility = View.VISIBLE
+            listView.adapter = FolderListAdapter(folders)
+            listView.setOnItemClickListener { _, _, position, _ ->
+                if (position in folders.indices) {
+                    launchWriteActivity(folders[position].name)
+                }
+            }
+        }
+    }
+
+    private inner class FolderListAdapter(private val items: List<FolderSummary>) : BaseAdapter() {
+        private val inflater: LayoutInflater = layoutInflater
+        private val accentColor: Int = ContextCompat.getColor(this@UsbFileListActivity, R.color.colorAccent)
+
+        override fun getCount(): Int = items.size
+
+        override fun getItem(position: Int): FolderSummary = items[position]
+
+        override fun getItemId(position: Int): Long = position.toLong()
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val view = convertView ?: inflater.inflate(R.layout.list_item_usb_folder, parent, false)
+            val artView = view.findViewById<ImageView>(R.id.usb_folder_album_art)
+            val titleView = view.findViewById<TextView>(R.id.usb_folder_title)
+            val artistView = view.findViewById<TextView>(R.id.usb_folder_artist)
+            val chevronView = view.findViewById<ImageView>(R.id.usb_folder_chevron)
+
+            val item = getItem(position)
+            val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
+            val artistText = item.artist ?: getString(R.string.usb_list_unknown_artist)
+
+            titleView.text = getString(R.string.usb_folder_title_format, item.name, albumText)
+            artistView.text = artistText
+
+            val artBytes = item.albumArt
+            if (artBytes != null) {
+                val bitmap = BitmapFactory.decodeByteArray(artBytes, 0, artBytes.size)
+                if (bitmap != null) {
+                    artView.setImageBitmap(bitmap)
+                } else {
+                    artView.setImageDrawable(null)
+                }
+            } else {
+                artView.setImageDrawable(null)
+            }
+
+            chevronView?.let {
+                ImageViewCompat.setImageTintList(it, ColorStateList.valueOf(accentColor))
+            }
+
+            return view
         }
     }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -16,6 +16,7 @@ import de.mw136.tonuino.nfc.NfcIntentActivity
 import de.mw136.tonuino.ui.enter.TagData
 import java.util.Locale
 import kotlin.ExperimentalUnsignedTypes
+import kotlin.math.roundToInt
 
 @ExperimentalUnsignedTypes
 class UsbFileListActivity : AppCompatActivity() {
@@ -71,6 +72,7 @@ class UsbFileListActivity : AppCompatActivity() {
     private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
         // Keep the header row defined in XML, append folder rows below
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
+        val verticalSpacing = (albumArtSize * 0.2f).roundToInt().coerceAtLeast(1)
         for (summary in folders) {
             val row = TableRow(this).apply {
                 isClickable = true
@@ -103,11 +105,18 @@ class UsbFileListActivity : AppCompatActivity() {
                 text = summary.album ?: getString(R.string.usb_list_unknown_album)
                 layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
             }
-            row.addView(artView)
             row.addView(nameView)
+            row.addView(artView)
             row.addView(artistView)
             row.addView(albumView)
-            table.addView(row)
+
+            val rowLayoutParams = TableLayout.LayoutParams(
+                TableLayout.LayoutParams.MATCH_PARENT,
+                TableLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                setMargins(0, verticalSpacing, 0, verticalSpacing)
+            }
+            table.addView(row, rowLayoutParams)
         }
     }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,5 +1,6 @@
 package de.mw136.tonuino.ui
 
+import android.media.MediaMetadataRetriever
 import android.os.Bundle
 import android.view.View
 import android.widget.TableLayout
@@ -7,8 +8,8 @@ import android.widget.TableRow
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.documentfile.provider.DocumentFile
-import java.util.Locale
 import de.mw136.tonuino.R
+import java.util.Locale
 
 class UsbFileListActivity : AppCompatActivity() {
     private val hiddenTopLevelFolderNames = setOf("advert", "mp3", "lost.dir")
@@ -67,8 +68,18 @@ class UsbFileListActivity : AppCompatActivity() {
                 layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
                 textAlignment = View.TEXT_ALIGNMENT_TEXT_END
             }
+            val artistView = TextView(this).apply {
+                text = summary.artist ?: getString(R.string.usb_list_unknown_artist)
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            val albumView = TextView(this).apply {
+                text = summary.album ?: getString(R.string.usb_list_unknown_album)
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+            }
             row.addView(nameView)
             row.addView(countView)
+            row.addView(artistView)
+            row.addView(albumView)
             table.addView(row)
         }
     }
@@ -82,9 +93,16 @@ class UsbFileListActivity : AppCompatActivity() {
             }
             .map { dir ->
                 val name = dir.name ?: getString(R.string.usb_folder_unknown_name)
-                FolderSummary(name, countFiles(dir))
+                val metadata = summarizeFolderMp3Metadata(dir)
+                FolderSummary(
+                    name = name,
+                    fileCount = countFiles(dir),
+                    artist = metadata.mostCommonArtist,
+                    album = metadata.mostCommonAlbum,
+                    albumArt = metadata.albumArt
+                )
             }
-            .sortedBy { it.name.lowercase() }
+            .sortedBy { it.name.lowercase(Locale.ROOT) }
 
     private fun countFiles(folder: DocumentFile): Int {
         var count = 0
@@ -97,6 +115,88 @@ class UsbFileListActivity : AppCompatActivity() {
         }
         return count
     }
+
+    private fun summarizeFolderMp3Metadata(folder: DocumentFile): FolderMetadataSummary {
+        val artistCounts = mutableMapOf<String, Int>()
+        val albumCounts = mutableMapOf<String, Int>()
+        var albumArt: ByteArray? = null
+
+        fun traverse(doc: DocumentFile) {
+            if (doc.isDirectory) {
+                doc.listFiles().forEach { traverse(it) }
+                return
+            }
+
+            if (doc.name?.endsWith(".mp3", ignoreCase = true) == true) {
+                val metadata = readMp3Metadata(doc)
+                metadata.artist?.let { artist ->
+                    artistCounts[artist] = (artistCounts[artist] ?: 0) + 1
+                }
+                metadata.album?.let { album ->
+                    albumCounts[album] = (albumCounts[album] ?: 0) + 1
+                }
+                if (albumArt == null && metadata.albumArt != null) {
+                    albumArt = metadata.albumArt
+                }
+            }
+        }
+
+        traverse(folder)
+
+        return FolderMetadataSummary(
+            mostCommonArtist = mostCommon(artistCounts),
+            mostCommonAlbum = mostCommon(albumCounts),
+            albumArt = albumArt
+        )
+    }
+
+    private fun readMp3Metadata(file: DocumentFile): Mp3Metadata {
+        var artist: String? = null
+        var album: String? = null
+        var albumArt: ByteArray? = null
+
+        try {
+            contentResolver.openFileDescriptor(file.uri, "r")?.use { fd ->
+                val retriever = MediaMetadataRetriever()
+                try {
+                    retriever.setDataSource(fd.fileDescriptor)
+                    artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)?.trim().orEmpty()
+                        .takeIf { it.isNotEmpty() }
+                    album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)?.trim().orEmpty()
+                        .takeIf { it.isNotEmpty() }
+                    albumArt = retriever.embeddedPicture
+                } finally {
+                    retriever.release()
+                }
+            }
+        } catch (_: Exception) {
+            // Ignore unreadable files; treat as missing metadata.
+        }
+
+        return Mp3Metadata(artist, album, albumArt)
+    }
+
+    private fun mostCommon(counts: Map<String, Int>): String? {
+        if (counts.isEmpty()) return null
+        return counts
+            .maxWithOrNull(compareBy<Map.Entry<String, Int>> { it.value }
+                .thenBy { it.key.lowercase(Locale.ROOT) })
+            ?.key
+    }
 }
 
-data class FolderSummary(val name: String, val fileCount: Int)
+data class FolderSummary(
+    val name: String,
+    val fileCount: Int,
+    val artist: String?,
+    val album: String?,
+    val albumArt: ByteArray?
+)
+
+data class FolderMetadataSummary(
+    val mostCommonArtist: String?,
+    val mostCommonAlbum: String?,
+    val albumArt: ByteArray?
+)
+
+data class Mp3Metadata(val artist: String?, val album: String?, val albumArt: ByteArray?)

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -38,8 +38,8 @@ import kotlin.ExperimentalUnsignedTypes
 
 @ExperimentalUnsignedTypes
 class UsbFileListActivity : AppCompatActivity() {
-    private val hiddenTopLevelFolderNames = setOf("advert", "mp3", "lost.dir")
-    private val selectableFolderRange = 1..99
+    private val folderNamePattern = Regex("^\\d{2}$")
+    private val selectableFolderRange = 0..99
     private val scanExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -113,6 +113,7 @@ class UsbFileListActivity : AppCompatActivity() {
     }
 
     private fun parseSelectableFolderNumber(name: String): Int? {
+        if (!folderNamePattern.matches(name.trim())) return null
         val numeric = name.trim().toIntOrNull() ?: return null
         return if (numeric in selectableFolderRange) numeric else null
     }
@@ -361,8 +362,6 @@ class UsbFileListActivity : AppCompatActivity() {
             .filter { it.isDirectory }
             .mapNotNull { dir ->
                 val rawName = dir.name ?: return@mapNotNull null
-                if (hiddenTopLevelFolderNames.contains(rawName.lowercase(Locale.ROOT))) return@mapNotNull null
-
                 val folderNumber = parseSelectableFolderNumber(rawName) ?: return@mapNotNull null
                 folderNumber.toString().padStart(2, '0') to dir
             }

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -7,9 +7,12 @@ import android.widget.TableRow
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.documentfile.provider.DocumentFile
+import java.util.Locale
 import de.mw136.tonuino.R
 
 class UsbFileListActivity : AppCompatActivity() {
+    private val hiddenTopLevelFolderNames = setOf("advert", "mp3", "lost.dir")
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_usb_file_list)
@@ -73,6 +76,10 @@ class UsbFileListActivity : AppCompatActivity() {
     private fun topLevelFolderSummaries(root: DocumentFile): List<FolderSummary> =
         root.listFiles()
             .filter { it.isDirectory }
+            .filterNot { dir ->
+                val name = dir.name ?: return@filterNot false
+                hiddenTopLevelFolderNames.contains(name.lowercase(Locale.ROOT))
+            }
             .map { dir ->
                 val name = dir.name ?: getString(R.string.usb_folder_unknown_name)
                 FolderSummary(name, countFiles(dir))

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -2,12 +2,14 @@ package de.mw136.tonuino.ui
 
 import android.app.AlertDialog
 import android.content.Intent
+import android.content.res.ColorStateList
 import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.TypedValue
 import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -16,6 +18,8 @@ import android.widget.TableRow
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.documentfile.provider.DocumentFile
+import androidx.core.content.ContextCompat
+import androidx.core.widget.ImageViewCompat
 import de.mw136.tonuino.R
 import de.mw136.tonuino.nfc.NfcIntentActivity
 import de.mw136.tonuino.ui.enter.TagData
@@ -95,12 +99,15 @@ class UsbFileListActivity : AppCompatActivity() {
         val verticalSpacing = (albumArtSize * 0.2f).roundToInt().coerceAtLeast(1)
         val horizontalSpacing = resources.getDimensionPixelSize(R.dimen.usb_table_horizontal_spacing)
         val halfHorizontalSpacing = (horizontalSpacing / 2f).roundToInt().coerceAtLeast(0)
+        val accentColor = ContextCompat.getColor(this, R.color.colorAccent)
+        val selectableBackground = selectableItemBackgroundRes()
 
         applyHorizontalSpacingToHeader(table, halfHorizontalSpacing)
         for (summary in folders) {
             val row = TableRow(this).apply {
                 isClickable = true
                 isFocusable = true
+                setBackgroundResource(selectableBackground)
                 setOnClickListener { launchWriteActivity(summary.name) }
             }
             val artView = ImageView(this).apply {
@@ -135,10 +142,20 @@ class UsbFileListActivity : AppCompatActivity() {
                     setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
                 }
             }
+            val chevronView = ImageView(this).apply {
+                setImageResource(R.drawable.ic_chevron_right_24)
+                ImageViewCompat.setImageTintList(this, ColorStateList.valueOf(accentColor))
+                layoutParams = TableRow.LayoutParams(
+                    TableRow.LayoutParams.WRAP_CONTENT,
+                    TableRow.LayoutParams.WRAP_CONTENT
+                ).apply { setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0) }
+                contentDescription = getString(R.string.usb_list_row_action_hint)
+            }
             row.addView(nameView)
             row.addView(artView)
             row.addView(artistView)
             row.addView(albumView)
+            row.addView(chevronView)
 
             val rowLayoutParams = TableLayout.LayoutParams(
                 TableLayout.LayoutParams.MATCH_PARENT,
@@ -163,6 +180,12 @@ class UsbFileListActivity : AppCompatActivity() {
             params.setMargins(halfSpacing, params.topMargin, halfSpacing, params.bottomMargin)
             child.layoutParams = params
         }
+    }
+
+    private fun selectableItemBackgroundRes(): Int {
+        val outValue = TypedValue()
+        theme.resolveAttribute(android.R.attr.selectableItemBackground, outValue, true)
+        return outValue.resourceId
     }
 
     private fun launchWriteActivity(folderName: String) {

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,0 +1,67 @@
+package de.mw136.tonuino.ui
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.documentfile.provider.DocumentFile
+import de.mw136.tonuino.R
+
+class UsbFileListActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_usb_file_list)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.usb_list_title)
+
+        val statusView = findViewById<TextView>(R.id.usb_file_list_text)
+        statusView.text = getString(R.string.usb_list_loading)
+
+        val uri = intent?.data
+        if (uri == null) {
+            statusView.text = getString(R.string.usb_list_no_uri)
+            return
+        }
+
+        val root = DocumentFile.fromTreeUri(this, uri)
+        if (root == null) {
+            statusView.text = getString(R.string.usb_list_error)
+            return
+        }
+
+        val files = listFilesRecursively(root)
+        if (files.isEmpty()) {
+            statusView.text = getString(R.string.main_usb_no_files)
+            return
+        }
+
+        val message = buildString {
+            appendLine(getString(R.string.main_usb_listing_prefix))
+            files.forEach { appendLine(it) }
+        }.trimEnd()
+
+        statusView.text = message
+        Log.i("UsbFileList", "Files on USB drive:\n$message")
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+
+    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
+        val collected = mutableListOf<String>()
+        for (child in node.listFiles()) {
+            val name = child.name ?: "(unnamed)"
+            val path = if (prefix.isEmpty()) name else "$prefix/$name"
+            if (child.isDirectory) {
+                collected.add("$path/")
+                collected.addAll(listFilesRecursively(child, path))
+            } else {
+                collected.add(path)
+            }
+        }
+        return collected
+    }
+}

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -173,6 +173,8 @@ class UsbFileListActivity : AppCompatActivity() {
 
             val item = getItem(position)
             if (item.albumDominant) {
+                artistView.visibility = View.VISIBLE
+
                 val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
                 val artistText = item.artist ?: getString(R.string.usb_list_unknown_artist)
 
@@ -191,9 +193,20 @@ class UsbFileListActivity : AppCompatActivity() {
                     artView.setImageDrawable(null)
                 }
             } else {
-                val trackLabel = getString(R.string.usb_list_track_count, item.trackCount)
+                val isEmpty = item.trackCount == 0
+                val trackLabel = if (isEmpty) {
+                    getString(R.string.usb_list_empty_folder)
+                } else {
+                    getString(R.string.usb_list_track_count, item.trackCount)
+                }
                 titleView.text = getString(R.string.usb_folder_title_format, item.name, trackLabel)
-                artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
+                if (isEmpty) {
+                    artistView.text = ""
+                    artistView.visibility = View.GONE
+                } else {
+                    artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
+                    artistView.visibility = View.VISIBLE
+                }
                 artView.setImageDrawable(null)
             }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,14 +1,20 @@
 package de.mw136.tonuino.ui
 
 import android.app.AlertDialog
+import android.content.BroadcastReceiver
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.res.ColorStateList
 import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
+import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -37,9 +43,39 @@ class UsbFileListActivity : AppCompatActivity() {
     private val scanExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
 
+    private var currentScanId = 0
+    private var storageReceiverRegistered = false
+    private var storageVolumeCallbackRegistered = false
+    private var rootUri: Uri? = null
+
+    private lateinit var statusView: TextView
+    private lateinit var listView: ListView
+
     private var progressDialog: AlertDialog? = null
     private var progressBar: ProgressBar? = null
     private var progressText: TextView? = null
+
+    private val storageReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: android.content.Context?, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_MEDIA_MOUNTED -> handleStorageMounted()
+                Intent.ACTION_MEDIA_UNMOUNTED, Intent.ACTION_MEDIA_REMOVED, Intent.ACTION_MEDIA_EJECT -> handleStorageRemoved()
+            }
+        }
+    }
+
+    private val storageVolumeCallback =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) object : StorageManager.StorageVolumeCallback() {
+            override fun onStateChanged(volume: StorageVolume) {
+                if (!volume.isRemovable) return
+                when (volume.state) {
+                    Environment.MEDIA_MOUNTED -> handleStorageMounted()
+                    else -> handleStorageRemoved()
+                }
+            }
+        } else {
+            null
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,31 +84,21 @@ class UsbFileListActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = getString(R.string.usb_list_title)
 
-        val statusView = findViewById<TextView>(R.id.usb_file_list_status)
-        val listView = findViewById<ListView>(R.id.usb_folder_list)
+        statusView = findViewById(R.id.usb_file_list_status)
+        listView = findViewById(R.id.usb_folder_list)
 
-        val uri = intent?.data
-        if (uri == null) {
-            statusView.text = getString(R.string.usb_list_no_uri)
-            listView.visibility = View.GONE
-            return
-        }
+        rootUri = intent?.data
+        startScan(useCache = true)
+    }
 
-        val root = DocumentFile.fromTreeUri(this, uri)
-        if (root == null) {
-            statusView.text = getString(R.string.usb_list_error)
-            listView.visibility = View.GONE
-            return
-        }
+    override fun onStart() {
+        super.onStart()
+        registerStorageObservers()
+    }
 
-        val cachedFolders = UsbFolderCache.getCachedFolders(this, uri)
-        if (cachedFolders != null) {
-            showFolderSummaries(statusView, listView, cachedFolders)
-            return
-        }
-
-        statusView.text = getString(R.string.usb_list_loading)
-        scanFoldersAsync(root, uri, listView, statusView)
+    override fun onStop() {
+        super.onStop()
+        unregisterStorageObservers()
     }
 
     override fun onDestroy() {
@@ -108,26 +134,56 @@ class UsbFileListActivity : AppCompatActivity() {
         })
     }
 
+    private fun startScan(useCache: Boolean) {
+        val uri = rootUri
+        if (uri == null) {
+            statusView.text = getString(R.string.usb_list_no_uri)
+            listView.visibility = View.GONE
+            return
+        }
+
+        val root = DocumentFile.fromTreeUri(this, uri)
+        if (root == null) {
+            statusView.text = getString(R.string.usb_list_error)
+            listView.visibility = View.GONE
+            return
+        }
+
+        if (useCache) {
+            val cachedFolders = UsbFolderCache.getCachedFolders(this, uri)
+            if (cachedFolders != null) {
+                showFolderSummaries(statusView, listView, cachedFolders)
+                return
+            }
+        }
+
+        statusView.visibility = View.VISIBLE
+        statusView.text = getString(R.string.usb_list_loading)
+        listView.visibility = View.GONE
+        scanFoldersAsync(root, uri, listView, statusView)
+    }
+
     private fun scanFoldersAsync(
         root: DocumentFile,
         uri: Uri,
         listView: ListView,
         statusView: TextView
     ) {
+        val scanId = ++currentScanId
         showProgressDialog()
-        updateScanProgress(0, 0)
+        updateScanProgress(0, 0, scanId)
         scanExecutor.execute {
             val folders = collectTopLevelFolders(root)
             val totalMp3Files = countEligibleMp3Files(folders)
-            updateScanProgress(0, totalMp3Files)
+            updateScanProgress(0, totalMp3Files, scanId)
 
             val summaries = buildFolderSummaries(folders, totalMp3Files) { processed, total ->
-                updateScanProgress(processed, total)
+                updateScanProgress(processed, total, scanId)
             }
             UsbFolderCache.save(this, uri, summaries)
 
             mainHandler.post {
-                if (isFinishing || isDestroyed) return@post
+                if (isFinishing || isDestroyed || scanId != currentScanId) return@post
                 dismissProgressDialog()
                 showFolderSummaries(statusView, listView, summaries)
             }
@@ -152,6 +208,56 @@ class UsbFileListActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun registerStorageObservers() {
+        if (!storageReceiverRegistered) {
+            val filter = IntentFilter().apply {
+                addAction(Intent.ACTION_MEDIA_MOUNTED)
+                addAction(Intent.ACTION_MEDIA_UNMOUNTED)
+                addAction(Intent.ACTION_MEDIA_REMOVED)
+                addAction(Intent.ACTION_MEDIA_EJECT)
+                addDataScheme("file")
+            }
+            registerReceiver(storageReceiver, filter)
+            storageReceiverRegistered = true
+        }
+
+        if (!storageVolumeCallbackRegistered && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            storageVolumeCallback?.let { callback ->
+                getSystemService(StorageManager::class.java)?.registerStorageVolumeCallback(mainExecutor, callback)
+                storageVolumeCallbackRegistered = true
+            }
+        }
+    }
+
+    private fun unregisterStorageObservers() {
+        if (storageReceiverRegistered) {
+            try {
+                unregisterReceiver(storageReceiver)
+            } catch (_: IllegalArgumentException) {
+            }
+            storageReceiverRegistered = false
+        }
+        if (storageVolumeCallbackRegistered && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            storageVolumeCallback?.let { callback ->
+                getSystemService(StorageManager::class.java)?.unregisterStorageVolumeCallback(callback)
+            }
+            storageVolumeCallbackRegistered = false
+        }
+    }
+
+    private fun handleStorageMounted() {
+        UsbFolderCache.clear()
+        startScan(useCache = false)
+    }
+
+    private fun handleStorageRemoved() {
+        UsbFolderCache.clear()
+        dismissProgressDialog()
+        statusView.visibility = View.VISIBLE
+        statusView.text = getString(R.string.usb_list_error)
+        listView.visibility = View.GONE
     }
 
     private inner class FolderListAdapter(private val items: List<FolderSummary>) : BaseAdapter() {
@@ -417,7 +523,8 @@ class UsbFileListActivity : AppCompatActivity() {
         progressDialog?.show()
     }
 
-    private fun updateScanProgress(processed: Int, total: Int) {
+    private fun updateScanProgress(processed: Int, total: Int, scanId: Int) {
+        if (scanId != currentScanId) return
         mainHandler.post {
             val bar = progressBar ?: return@post
             val textView = progressText

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -61,12 +61,10 @@ class UsbFileListActivity : AppCompatActivity() {
             val row = TableRow(this)
             val nameView = TextView(this).apply {
                 text = summary.name
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
-            }
-            val countView = TextView(this).apply {
-                text = summary.fileCount.toString()
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
-                textAlignment = View.TEXT_ALIGNMENT_TEXT_END
+                layoutParams = TableRow.LayoutParams(
+                    TableRow.LayoutParams.WRAP_CONTENT,
+                    TableRow.LayoutParams.WRAP_CONTENT
+                )
             }
             val artistView = TextView(this).apply {
                 text = summary.artist ?: getString(R.string.usb_list_unknown_artist)
@@ -77,7 +75,6 @@ class UsbFileListActivity : AppCompatActivity() {
                 layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
             }
             row.addView(nameView)
-            row.addView(countView)
             row.addView(artistView)
             row.addView(albumView)
             table.addView(row)
@@ -96,25 +93,12 @@ class UsbFileListActivity : AppCompatActivity() {
                 val metadata = summarizeFolderMp3Metadata(dir)
                 FolderSummary(
                     name = name,
-                    fileCount = countFiles(dir),
                     artist = metadata.mostCommonArtist,
                     album = metadata.mostCommonAlbum,
                     albumArt = metadata.albumArt
                 )
             }
             .sortedBy { it.name.lowercase(Locale.ROOT) }
-
-    private fun countFiles(folder: DocumentFile): Int {
-        var count = 0
-        for (child in folder.listFiles()) {
-            if (child.isDirectory) {
-                count += countFiles(child)
-            } else {
-                count += 1
-            }
-        }
-        return count
-    }
 
     private fun summarizeFolderMp3Metadata(folder: DocumentFile): FolderMetadataSummary {
         val artistCounts = mutableMapOf<String, Int>()
@@ -187,7 +171,6 @@ class UsbFileListActivity : AppCompatActivity() {
 
 data class FolderSummary(
     val name: String,
-    val fileCount: Int,
     val artist: String?,
     val album: String?,
     val albumArt: ByteArray?

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,11 +1,16 @@
 package de.mw136.tonuino.ui
 
+import android.app.AlertDialog
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TableLayout
 import android.widget.TableRow
 import android.widget.TextView
@@ -15,6 +20,8 @@ import de.mw136.tonuino.R
 import de.mw136.tonuino.nfc.NfcIntentActivity
 import de.mw136.tonuino.ui.enter.TagData
 import java.util.Locale
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import kotlin.ExperimentalUnsignedTypes
 import kotlin.math.roundToInt
 
@@ -22,6 +29,12 @@ import kotlin.math.roundToInt
 class UsbFileListActivity : AppCompatActivity() {
     private val hiddenTopLevelFolderNames = setOf("advert", "mp3", "lost.dir")
     private val selectableFolderRange = 1..99
+    private val scanExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var progressDialog: AlertDialog? = null
+    private var progressBar: ProgressBar? = null
+    private var progressText: TextView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,7 +45,6 @@ class UsbFileListActivity : AppCompatActivity() {
 
         val statusView = findViewById<TextView>(R.id.usb_file_list_status)
         val table = findViewById<TableLayout>(R.id.usb_file_table)
-        statusView.text = getString(R.string.usb_list_loading)
 
         val uri = intent?.data
         if (uri == null) {
@@ -49,17 +61,19 @@ class UsbFileListActivity : AppCompatActivity() {
         }
 
         val cachedFolders = UsbFolderCache.getCachedFolders(this, uri)
-        val folders = cachedFolders ?: topLevelFolderSummaries(root).also { summaries ->
-            UsbFolderCache.save(this, uri, summaries)
-        }
-        if (folders.isEmpty()) {
-            statusView.text = getString(R.string.usb_list_no_folders)
-            table.visibility = View.GONE
+        if (cachedFolders != null) {
+            showFolderSummaries(statusView, table, cachedFolders)
             return
         }
 
-        statusView.visibility = View.GONE
-        populateTable(table, folders)
+        statusView.text = getString(R.string.usb_list_loading)
+        scanFoldersAsync(root, uri, table, statusView)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scanExecutor.shutdownNow()
+        dismissProgressDialog()
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -74,6 +88,9 @@ class UsbFileListActivity : AppCompatActivity() {
 
     private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
         // Keep the header row defined in XML, append folder rows below
+        while (table.childCount > 1) {
+            table.removeViewAt(1)
+        }
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
         val verticalSpacing = (albumArtSize * 0.2f).roundToInt().coerceAtLeast(1)
         val horizontalSpacing = resources.getDimensionPixelSize(R.dimen.usb_table_horizontal_spacing)
@@ -156,7 +173,48 @@ class UsbFileListActivity : AppCompatActivity() {
         })
     }
 
-    private fun topLevelFolderSummaries(root: DocumentFile): List<FolderSummary> =
+    private fun scanFoldersAsync(
+        root: DocumentFile,
+        uri: Uri,
+        table: TableLayout,
+        statusView: TextView
+    ) {
+        showProgressDialog()
+        updateScanProgress(0, 0)
+        scanExecutor.execute {
+            val folders = collectTopLevelFolders(root)
+            val totalMp3Files = countEligibleMp3Files(folders)
+            updateScanProgress(0, totalMp3Files)
+
+            val summaries = buildFolderSummaries(folders, totalMp3Files) { processed, total ->
+                updateScanProgress(processed, total)
+            }
+            UsbFolderCache.save(this, uri, summaries)
+
+            mainHandler.post {
+                if (isFinishing || isDestroyed) return@post
+                dismissProgressDialog()
+                showFolderSummaries(statusView, table, summaries)
+            }
+        }
+    }
+
+    private fun showFolderSummaries(
+        statusView: TextView,
+        table: TableLayout,
+        folders: List<FolderSummary>
+    ) {
+        if (folders.isEmpty()) {
+            statusView.text = getString(R.string.usb_list_no_folders)
+            table.visibility = View.GONE
+        } else {
+            statusView.visibility = View.GONE
+            table.visibility = View.VISIBLE
+            populateTable(table, folders)
+        }
+    }
+
+    private fun collectTopLevelFolders(root: DocumentFile): List<Pair<String, DocumentFile>> =
         root.listFiles()
             .filter { it.isDirectory }
             .mapNotNull { dir ->
@@ -164,17 +222,49 @@ class UsbFileListActivity : AppCompatActivity() {
                 if (hiddenTopLevelFolderNames.contains(rawName.lowercase(Locale.ROOT))) return@mapNotNull null
 
                 val folderNumber = parseSelectableFolderNumber(rawName) ?: return@mapNotNull null
-                val metadata = summarizeFolderMp3Metadata(dir)
-                FolderSummary(
-                    name = folderNumber.toString().padStart(2, '0'),
-                    artist = metadata.mostCommonArtist,
-                    album = metadata.mostCommonAlbum,
-                    albumArt = metadata.albumArt
-                )
+                folderNumber.toString().padStart(2, '0') to dir
             }
-            .sortedBy { it.name.lowercase(Locale.ROOT) }
+            .sortedBy { it.first.lowercase(Locale.ROOT) }
 
-    private fun summarizeFolderMp3Metadata(folder: DocumentFile): FolderMetadataSummary {
+    private fun countEligibleMp3Files(folders: List<Pair<String, DocumentFile>>): Int {
+        var total = 0
+
+        fun traverse(doc: DocumentFile) {
+            if (doc.isDirectory) {
+                doc.listFiles().forEach { traverse(it) }
+            } else if (doc.name?.endsWith(".mp3", ignoreCase = true) == true) {
+                total++
+            }
+        }
+
+        folders.forEach { (_, dir) -> traverse(dir) }
+        return total
+    }
+
+    private fun buildFolderSummaries(
+        folders: List<Pair<String, DocumentFile>>,
+        totalMp3Files: Int,
+        onFileProcessed: (processed: Int, total: Int) -> Unit
+    ): List<FolderSummary> {
+        var processed = 0
+        return folders.map { (name, dir) ->
+            val metadata = summarizeFolderMp3Metadata(dir) {
+                processed++
+                onFileProcessed(processed, totalMp3Files)
+            }
+            FolderSummary(
+                name = name,
+                artist = metadata.mostCommonArtist,
+                album = metadata.mostCommonAlbum,
+                albumArt = metadata.albumArt
+            )
+        }
+    }
+
+    private fun summarizeFolderMp3Metadata(
+        folder: DocumentFile,
+        onMp3Processed: () -> Unit
+    ): FolderMetadataSummary {
         val artistCounts = mutableMapOf<String, Int>()
         val albumCounts = mutableMapOf<String, Int>()
         var albumArt: ByteArray? = null
@@ -196,6 +286,7 @@ class UsbFileListActivity : AppCompatActivity() {
                 if (albumArt == null && metadata.albumArt != null) {
                     albumArt = metadata.albumArt
                 }
+                onMp3Processed()
             }
         }
 
@@ -240,6 +331,47 @@ class UsbFileListActivity : AppCompatActivity() {
             .maxWithOrNull(compareBy<Map.Entry<String, Int>> { it.value }
                 .thenBy { it.key.lowercase(Locale.ROOT) })
             ?.key
+    }
+
+    private fun showProgressDialog() {
+        if (progressDialog?.isShowing == true) return
+        val view = layoutInflater.inflate(R.layout.dialog_usb_scan_progress, null)
+        progressBar = view.findViewById(R.id.usb_scan_progress_bar)
+        progressText = view.findViewById(R.id.usb_scan_progress_text)
+        progressText?.text = getString(R.string.usb_scan_preparing)
+        progressBar?.isIndeterminate = true
+
+        progressDialog = AlertDialog.Builder(this)
+            .setTitle(R.string.usb_scan_dialog_title)
+            .setView(view)
+            .setCancelable(false)
+            .create()
+        progressDialog?.show()
+    }
+
+    private fun updateScanProgress(processed: Int, total: Int) {
+        mainHandler.post {
+            val bar = progressBar ?: return@post
+            val textView = progressText
+            if (total <= 0) {
+                bar.isIndeterminate = true
+                textView?.text = getString(R.string.usb_scan_preparing)
+            } else {
+                bar.isIndeterminate = false
+                bar.max = total
+                bar.progress = processed.coerceAtMost(total)
+                textView?.text = getString(R.string.usb_scan_progress, processed, total)
+            }
+        }
+    }
+
+    private fun dismissProgressDialog() {
+        mainHandler.post {
+            progressDialog?.dismiss()
+            progressDialog = null
+            progressBar = null
+            progressText = null
+        }
     }
 }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -22,8 +22,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
 import androidx.documentfile.provider.DocumentFile
 import de.mw136.tonuino.R
-import de.mw136.tonuino.ui.Format1Mode
 import de.mw136.tonuino.nfc.NfcIntentActivity
+import de.mw136.tonuino.ui.Format1Mode
 import de.mw136.tonuino.ui.enter.TagData
 import java.util.Locale
 import java.util.concurrent.ExecutorService
@@ -91,11 +91,17 @@ class UsbFileListActivity : AppCompatActivity() {
         return if (numeric in selectableFolderRange) numeric else null
     }
 
-    private fun launchWriteActivity(folderName: String) {
-        val folderNumber = parseSelectableFolderNumber(folderName) ?: return
+    private fun launchWriteActivity(summary: FolderSummary) {
+        val folderNumber = parseSelectableFolderNumber(summary.name) ?: return
+        val modeValue = if (summary.albumDominant) {
+            Format1Mode.AudioBookMultiple.value
+        } else {
+            // For mixed albums fall back to simple album playback.
+            Format1Mode.Album.value
+        }
         val tagData = TagData().apply {
             setFolder(folderNumber.toUByte())
-            setMode(Format1Mode.AudioBookMultiple.value.toUByte())
+            setMode(modeValue.toUByte())
         }
         startActivity(Intent(this, EnterTagActivity::class.java).apply {
             putExtra(NfcIntentActivity.PARCEL_TAGDATA, tagData)
@@ -142,7 +148,7 @@ class UsbFileListActivity : AppCompatActivity() {
             listView.adapter = FolderListAdapter(folders)
             listView.setOnItemClickListener { _, _, position, _ ->
                 if (position in folders.indices) {
-                    launchWriteActivity(folders[position].name)
+                    launchWriteActivity(folders[position])
                 }
             }
         }
@@ -166,21 +172,28 @@ class UsbFileListActivity : AppCompatActivity() {
             val chevronView = view.findViewById<ImageView>(R.id.usb_folder_chevron)
 
             val item = getItem(position)
-            val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
-            val artistText = item.artist ?: getString(R.string.usb_list_unknown_artist)
+            if (item.albumDominant) {
+                val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
+                val artistText = item.artist ?: getString(R.string.usb_list_unknown_artist)
 
-            titleView.text = getString(R.string.usb_folder_title_format, item.name, albumText)
-            artistView.text = artistText
+                titleView.text = getString(R.string.usb_folder_title_format, item.name, albumText)
+                artistView.text = artistText
 
-            val artBytes = item.albumArt
-            if (artBytes != null) {
-                val bitmap = BitmapFactory.decodeByteArray(artBytes, 0, artBytes.size)
-                if (bitmap != null) {
-                    artView.setImageBitmap(bitmap)
+                val artBytes = item.albumArt
+                if (artBytes != null) {
+                    val bitmap = BitmapFactory.decodeByteArray(artBytes, 0, artBytes.size)
+                    if (bitmap != null) {
+                        artView.setImageBitmap(bitmap)
+                    } else {
+                        artView.setImageDrawable(null)
+                    }
                 } else {
                     artView.setImageDrawable(null)
                 }
             } else {
+                val trackLabel = getString(R.string.usb_list_track_count, item.trackCount)
+                titleView.text = getString(R.string.usb_folder_title_format, item.name, trackLabel)
+                artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
                 artView.setImageDrawable(null)
             }
 
@@ -189,6 +202,18 @@ class UsbFileListActivity : AppCompatActivity() {
             }
 
             return view
+        }
+
+        private fun buildTrackPreview(titles: List<String>, totalCount: Int): String {
+            if (titles.isEmpty()) return getString(R.string.usb_list_unknown_artist)
+            val shortened = titles.take(3).map { shortenTitle(it) }
+            val base = shortened.joinToString(", ")
+            return if (totalCount > shortened.size) "$base, ..." else base
+        }
+
+        private fun shortenTitle(title: String, maxLen: Int = 22): String {
+            if (title.length <= maxLen) return title
+            return title.take(maxLen - 3).trimEnd() + "..."
         }
     }
 
@@ -230,11 +255,15 @@ class UsbFileListActivity : AppCompatActivity() {
                 processed++
                 onFileProcessed(processed, totalMp3Files)
             }
+            val dominantAlbum = metadata.hasDominantAlbum()
             FolderSummary(
                 name = name,
                 artist = metadata.mostCommonArtist,
                 album = metadata.mostCommonAlbum,
-                albumArt = metadata.albumArt
+                albumArt = if (dominantAlbum) metadata.albumArt else null,
+                albumDominant = dominantAlbum,
+                trackCount = metadata.trackCount,
+                trackTitles = metadata.trackTitles
             )
         }
     }
@@ -246,6 +275,8 @@ class UsbFileListActivity : AppCompatActivity() {
         val artistCounts = mutableMapOf<String, Int>()
         val albumCounts = mutableMapOf<String, Int>()
         var albumArt: ByteArray? = null
+        val trackTitles = mutableListOf<String>()
+        var trackCount = 0
 
         fun traverse(doc: DocumentFile) {
             if (doc.isDirectory) {
@@ -261,9 +292,13 @@ class UsbFileListActivity : AppCompatActivity() {
                 metadata.album?.let { album ->
                     albumCounts[album] = (albumCounts[album] ?: 0) + 1
                 }
+                metadata.title?.let { title ->
+                    if (trackTitles.size < 3) trackTitles.add(title)
+                }
                 if (albumArt == null && metadata.albumArt != null) {
                     albumArt = metadata.albumArt
                 }
+                trackCount++
                 onMp3Processed()
             }
         }
@@ -273,7 +308,10 @@ class UsbFileListActivity : AppCompatActivity() {
         return FolderMetadataSummary(
             mostCommonArtist = mostCommon(artistCounts),
             mostCommonAlbum = mostCommon(albumCounts),
-            albumArt = albumArt
+            albumArt = albumArt,
+            trackCount = trackCount,
+            trackTitles = trackTitles.toList(),
+            mostCommonAlbumCount = albumCounts.maxOfOrNull { it.value } ?: 0
         )
     }
 
@@ -281,6 +319,7 @@ class UsbFileListActivity : AppCompatActivity() {
         var artist: String? = null
         var album: String? = null
         var albumArt: ByteArray? = null
+        var title: String? = null
 
         try {
             contentResolver.openFileDescriptor(file.uri, "r")?.use { fd ->
@@ -291,6 +330,8 @@ class UsbFileListActivity : AppCompatActivity() {
                         .takeIf { it.isNotEmpty() }
                     album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)?.trim().orEmpty()
                         .takeIf { it.isNotEmpty() }
+                    title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)?.trim().orEmpty()
+                        .takeIf { it.isNotEmpty() }
                     albumArt = retriever.embeddedPicture
                 } finally {
                     retriever.release()
@@ -300,7 +341,14 @@ class UsbFileListActivity : AppCompatActivity() {
             // Ignore unreadable files; treat as missing metadata.
         }
 
-        return Mp3Metadata(artist, album, albumArt)
+        if (title == null) {
+            val rawName = file.name
+            if (rawName != null) {
+                title = rawName.substringBeforeLast('.', rawName)
+            }
+        }
+
+        return Mp3Metadata(artist, album, albumArt, title)
     }
 
     private fun mostCommon(counts: Map<String, Int>): String? {
@@ -357,13 +405,29 @@ data class FolderSummary(
     val name: String,
     val artist: String?,
     val album: String?,
-    val albumArt: ByteArray?
+    val albumArt: ByteArray?,
+    val albumDominant: Boolean,
+    val trackCount: Int,
+    val trackTitles: List<String>
 )
 
 data class FolderMetadataSummary(
     val mostCommonArtist: String?,
     val mostCommonAlbum: String?,
-    val albumArt: ByteArray?
-)
+    val albumArt: ByteArray?,
+    val trackCount: Int,
+    val trackTitles: List<String>,
+    val mostCommonAlbumCount: Int
+) {
+    fun hasDominantAlbum(threshold: Double = 0.8): Boolean {
+        if (trackCount == 0) return false
+        return mostCommonAlbumCount.toDouble() >= (trackCount * threshold)
+    }
+}
 
-data class Mp3Metadata(val artist: String?, val album: String?, val albumArt: ByteArray?)
+data class Mp3Metadata(
+    val artist: String?,
+    val album: String?,
+    val albumArt: ByteArray?,
+    val title: String?
+)

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,5 +1,6 @@
 package de.mw136.tonuino.ui
 
+import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.os.Bundle
@@ -11,10 +12,15 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.documentfile.provider.DocumentFile
 import de.mw136.tonuino.R
+import de.mw136.tonuino.nfc.NfcIntentActivity
+import de.mw136.tonuino.ui.enter.TagData
 import java.util.Locale
+import kotlin.ExperimentalUnsignedTypes
 
+@ExperimentalUnsignedTypes
 class UsbFileListActivity : AppCompatActivity() {
     private val hiddenTopLevelFolderNames = setOf("advert", "mp3", "lost.dir")
+    private val selectableFolderRange = 1..99
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,11 +63,20 @@ class UsbFileListActivity : AppCompatActivity() {
         return true
     }
 
+    private fun parseSelectableFolderNumber(name: String): Int? {
+        val numeric = name.trim().toIntOrNull() ?: return null
+        return if (numeric in selectableFolderRange) numeric else null
+    }
+
     private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
         // Keep the header row defined in XML, append folder rows below
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
         for (summary in folders) {
-            val row = TableRow(this)
+            val row = TableRow(this).apply {
+                isClickable = true
+                isFocusable = true
+                setOnClickListener { launchWriteActivity(summary.name) }
+            }
             val artView = ImageView(this).apply {
                 layoutParams = TableRow.LayoutParams(albumArtSize, albumArtSize)
                 adjustViewBounds = true
@@ -96,18 +111,25 @@ class UsbFileListActivity : AppCompatActivity() {
         }
     }
 
+    private fun launchWriteActivity(folderName: String) {
+        val folderNumber = parseSelectableFolderNumber(folderName) ?: return
+        val tagData = TagData().apply { setFolder(folderNumber.toUByte()) }
+        startActivity(Intent(this, EnterTagActivity::class.java).apply {
+            putExtra(NfcIntentActivity.PARCEL_TAGDATA, tagData)
+        })
+    }
+
     private fun topLevelFolderSummaries(root: DocumentFile): List<FolderSummary> =
         root.listFiles()
             .filter { it.isDirectory }
-            .filterNot { dir ->
-                val name = dir.name ?: return@filterNot false
-                hiddenTopLevelFolderNames.contains(name.lowercase(Locale.ROOT))
-            }
-            .map { dir ->
-                val name = dir.name ?: getString(R.string.usb_folder_unknown_name)
+            .mapNotNull { dir ->
+                val rawName = dir.name ?: return@mapNotNull null
+                if (hiddenTopLevelFolderNames.contains(rawName.lowercase(Locale.ROOT))) return@mapNotNull null
+
+                val folderNumber = parseSelectableFolderNumber(rawName) ?: return@mapNotNull null
                 val metadata = summarizeFolderMp3Metadata(dir)
                 FolderSummary(
-                    name = name,
+                    name = folderNumber.toString().padStart(2, '0'),
                     artist = metadata.mostCommonArtist,
                     album = metadata.mostCommonAlbum,
                     albumArt = metadata.albumArt

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -48,7 +48,10 @@ class UsbFileListActivity : AppCompatActivity() {
             return
         }
 
-        val folders = topLevelFolderSummaries(root)
+        val cachedFolders = UsbFolderCache.getCachedFolders(this, uri)
+        val folders = cachedFolders ?: topLevelFolderSummaries(root).also { summaries ->
+            UsbFolderCache.save(this, uri, summaries)
+        }
         if (folders.isEmpty()) {
             statusView.text = getString(R.string.usb_list_no_folders)
             table.visibility = View.GONE

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -169,11 +169,16 @@ class UsbFileListActivity : AppCompatActivity() {
             val artView = view.findViewById<ImageView>(R.id.usb_folder_album_art)
             val titleView = view.findViewById<TextView>(R.id.usb_folder_title)
             val artistView = view.findViewById<TextView>(R.id.usb_folder_artist)
+            val trackCountView = view.findViewById<TextView>(R.id.usb_folder_track_count)
             val chevronView = view.findViewById<ImageView>(R.id.usb_folder_chevron)
 
             val item = getItem(position)
             if (item.albumDominant) {
                 artistView.visibility = View.VISIBLE
+                trackCountView.visibility = if (item.trackCount > 0) View.VISIBLE else View.GONE
+                if (item.trackCount > 0) {
+                    trackCountView.text = getString(R.string.usb_list_track_count, item.trackCount)
+                }
 
                 val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
                 val artistText = item.artist ?: getString(R.string.usb_list_unknown_artist)
@@ -194,6 +199,7 @@ class UsbFileListActivity : AppCompatActivity() {
                 }
             } else {
                 val isEmpty = item.trackCount == 0
+                trackCountView.visibility = if (isEmpty) View.GONE else View.VISIBLE
                 val trackLabel = if (isEmpty) {
                     getString(R.string.usb_list_empty_folder)
                 } else {
@@ -206,6 +212,7 @@ class UsbFileListActivity : AppCompatActivity() {
                 } else {
                     artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
                     artistView.visibility = View.VISIBLE
+                    trackCountView.text = getString(R.string.usb_list_track_count, item.trackCount)
                 }
                 artView.setImageDrawable(null)
             }

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -1,7 +1,9 @@
 package de.mw136.tonuino.ui
 
 import android.os.Bundle
-import android.util.Log
+import android.view.View
+import android.widget.TableLayout
+import android.widget.TableRow
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.documentfile.provider.DocumentFile
@@ -15,34 +17,33 @@ class UsbFileListActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = getString(R.string.usb_list_title)
 
-        val statusView = findViewById<TextView>(R.id.usb_file_list_text)
+        val statusView = findViewById<TextView>(R.id.usb_file_list_status)
+        val table = findViewById<TableLayout>(R.id.usb_file_table)
         statusView.text = getString(R.string.usb_list_loading)
 
         val uri = intent?.data
         if (uri == null) {
             statusView.text = getString(R.string.usb_list_no_uri)
+            table.visibility = View.GONE
             return
         }
 
         val root = DocumentFile.fromTreeUri(this, uri)
         if (root == null) {
             statusView.text = getString(R.string.usb_list_error)
+            table.visibility = View.GONE
             return
         }
 
-        val files = listFilesRecursively(root)
-        if (files.isEmpty()) {
-            statusView.text = getString(R.string.main_usb_no_files)
+        val folders = topLevelFolderSummaries(root)
+        if (folders.isEmpty()) {
+            statusView.text = getString(R.string.usb_list_no_folders)
+            table.visibility = View.GONE
             return
         }
 
-        val message = buildString {
-            appendLine(getString(R.string.main_usb_listing_prefix))
-            files.forEach { appendLine(it) }
-        }.trimEnd()
-
-        statusView.text = message
-        Log.i("UsbFileList", "Files on USB drive:\n$message")
+        statusView.visibility = View.GONE
+        populateTable(table, folders)
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -50,18 +51,45 @@ class UsbFileListActivity : AppCompatActivity() {
         return true
     }
 
-    private fun listFilesRecursively(node: DocumentFile, prefix: String = ""): List<String> {
-        val collected = mutableListOf<String>()
-        for (child in node.listFiles()) {
-            val name = child.name ?: "(unnamed)"
-            val path = if (prefix.isEmpty()) name else "$prefix/$name"
+    private fun populateTable(table: TableLayout, folders: List<FolderSummary>) {
+        // Keep the header row defined in XML, append folder rows below
+        for (summary in folders) {
+            val row = TableRow(this)
+            val nameView = TextView(this).apply {
+                text = summary.name
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            val countView = TextView(this).apply {
+                text = summary.fileCount.toString()
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+                textAlignment = View.TEXT_ALIGNMENT_TEXT_END
+            }
+            row.addView(nameView)
+            row.addView(countView)
+            table.addView(row)
+        }
+    }
+
+    private fun topLevelFolderSummaries(root: DocumentFile): List<FolderSummary> =
+        root.listFiles()
+            .filter { it.isDirectory }
+            .map { dir ->
+                val name = dir.name ?: getString(R.string.usb_folder_unknown_name)
+                FolderSummary(name, countFiles(dir))
+            }
+            .sortedBy { it.name.lowercase() }
+
+    private fun countFiles(folder: DocumentFile): Int {
+        var count = 0
+        for (child in folder.listFiles()) {
             if (child.isDirectory) {
-                collected.add("$path/")
-                collected.addAll(listFilesRecursively(child, path))
+                count += countFiles(child)
             } else {
-                collected.add(path)
+                count += 1
             }
         }
-        return collected
+        return count
     }
 }
+
+data class FolderSummary(val name: String, val fileCount: Int)

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -96,8 +96,8 @@ class UsbFileListActivity : AppCompatActivity() {
         val modeValue = if (summary.albumDominant) {
             Format1Mode.AudioBookMultiple.value
         } else {
-            // For mixed albums fall back to simple album playback.
-            Format1Mode.Album.value
+            // For mixed albums fall back to Party playback.
+            Format1Mode.Party.value
         }
         val tagData = TagData().apply {
             setFolder(folderNumber.toUByte())

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
 import androidx.documentfile.provider.DocumentFile
 import de.mw136.tonuino.R
+import de.mw136.tonuino.ui.Format1Mode
 import de.mw136.tonuino.nfc.NfcIntentActivity
 import de.mw136.tonuino.ui.enter.TagData
 import java.util.Locale
@@ -92,7 +93,10 @@ class UsbFileListActivity : AppCompatActivity() {
 
     private fun launchWriteActivity(folderName: String) {
         val folderNumber = parseSelectableFolderNumber(folderName) ?: return
-        val tagData = TagData().apply { setFolder(folderNumber.toUByte()) }
+        val tagData = TagData().apply {
+            setFolder(folderNumber.toUByte())
+            setMode(Format1Mode.AudioBookMultiple.value.toUByte())
+        }
         startActivity(Intent(this, EnterTagActivity::class.java).apply {
             putExtra(NfcIntentActivity.PARCEL_TAGDATA, tagData)
         })

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -177,7 +177,11 @@ class UsbFileListActivity : AppCompatActivity() {
                 artistView.visibility = View.VISIBLE
                 trackCountView.visibility = if (item.trackCount > 0) View.VISIBLE else View.GONE
                 if (item.trackCount > 0) {
-                    trackCountView.text = getString(R.string.usb_list_track_count, item.trackCount)
+                    trackCountView.text = getString(
+                        R.string.usb_list_track_count_with_duration,
+                        item.trackCount,
+                        formatDuration(item.totalDurationMs)
+                    )
                 }
 
                 val albumText = item.album ?: getString(R.string.usb_list_unknown_album)
@@ -209,7 +213,11 @@ class UsbFileListActivity : AppCompatActivity() {
                     artistView.text = buildTrackPreview(item.trackTitles, item.trackCount)
                     artistView.visibility = View.VISIBLE
                     trackCountView.visibility = View.VISIBLE
-                    trackCountView.text = getString(R.string.usb_list_track_count, item.trackCount)
+                    trackCountView.text = getString(
+                        R.string.usb_list_track_count_with_duration,
+                        item.trackCount,
+                        formatDuration(item.totalDurationMs)
+                    )
                 }
                 artView.setImageDrawable(null)
             }
@@ -231,6 +239,14 @@ class UsbFileListActivity : AppCompatActivity() {
         private fun shortenTitle(title: String, maxLen: Int = 22): String {
             if (title.length <= maxLen) return title
             return title.take(maxLen - 3).trimEnd() + "..."
+        }
+
+        private fun formatDuration(durationMs: Long): String {
+            val totalSeconds = (durationMs / 1000).coerceAtLeast(0)
+            val hours = totalSeconds / 3600
+            val minutes = (totalSeconds % 3600) / 60
+            val seconds = totalSeconds % 60
+            return String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
         }
     }
 
@@ -280,7 +296,8 @@ class UsbFileListActivity : AppCompatActivity() {
                 albumArt = if (dominantAlbum) metadata.albumArt else null,
                 albumDominant = dominantAlbum,
                 trackCount = metadata.trackCount,
-                trackTitles = metadata.trackTitles
+                trackTitles = metadata.trackTitles,
+                totalDurationMs = metadata.totalDurationMs
             )
         }
     }
@@ -294,6 +311,7 @@ class UsbFileListActivity : AppCompatActivity() {
         var albumArt: ByteArray? = null
         val trackTitles = mutableListOf<String>()
         var trackCount = 0
+        var totalDurationMs = 0L
 
         fun traverse(doc: DocumentFile) {
             if (doc.isDirectory) {
@@ -315,6 +333,9 @@ class UsbFileListActivity : AppCompatActivity() {
                 if (albumArt == null && metadata.albumArt != null) {
                     albumArt = metadata.albumArt
                 }
+                if (metadata.durationMs > 0) {
+                    totalDurationMs += metadata.durationMs
+                }
                 trackCount++
                 onMp3Processed()
             }
@@ -328,7 +349,8 @@ class UsbFileListActivity : AppCompatActivity() {
             albumArt = albumArt,
             trackCount = trackCount,
             trackTitles = trackTitles.toList(),
-            mostCommonAlbumCount = albumCounts.maxOfOrNull { it.value } ?: 0
+            mostCommonAlbumCount = albumCounts.maxOfOrNull { it.value } ?: 0,
+            totalDurationMs = totalDurationMs
         )
     }
 
@@ -337,6 +359,7 @@ class UsbFileListActivity : AppCompatActivity() {
         var album: String? = null
         var albumArt: ByteArray? = null
         var title: String? = null
+        var durationMs: Long = 0
 
         try {
             contentResolver.openFileDescriptor(file.uri, "r")?.use { fd ->
@@ -350,6 +373,8 @@ class UsbFileListActivity : AppCompatActivity() {
                     title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)?.trim().orEmpty()
                         .takeIf { it.isNotEmpty() }
                     albumArt = retriever.embeddedPicture
+                    durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        ?.toLongOrNull() ?: 0L
                 } finally {
                     retriever.release()
                 }
@@ -365,7 +390,7 @@ class UsbFileListActivity : AppCompatActivity() {
             }
         }
 
-        return Mp3Metadata(artist, album, albumArt, title)
+        return Mp3Metadata(artist, album, albumArt, title, durationMs)
     }
 
     private fun mostCommon(counts: Map<String, Int>): String? {
@@ -425,7 +450,8 @@ data class FolderSummary(
     val albumArt: ByteArray?,
     val albumDominant: Boolean,
     val trackCount: Int,
-    val trackTitles: List<String>
+    val trackTitles: List<String>,
+    val totalDurationMs: Long
 )
 
 data class FolderMetadataSummary(
@@ -434,7 +460,8 @@ data class FolderMetadataSummary(
     val albumArt: ByteArray?,
     val trackCount: Int,
     val trackTitles: List<String>,
-    val mostCommonAlbumCount: Int
+    val mostCommonAlbumCount: Int,
+    val totalDurationMs: Long
 ) {
     fun hasDominantAlbum(threshold: Double = 0.8): Boolean {
         if (trackCount == 0) return false
@@ -446,5 +473,6 @@ data class Mp3Metadata(
     val artist: String?,
     val album: String?,
     val albumArt: ByteArray?,
-    val title: String?
+    val title: String?,
+    val durationMs: Long
 )

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFileListActivity.kt
@@ -73,6 +73,10 @@ class UsbFileListActivity : AppCompatActivity() {
         // Keep the header row defined in XML, append folder rows below
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.usb_album_art_size)
         val verticalSpacing = (albumArtSize * 0.2f).roundToInt().coerceAtLeast(1)
+        val horizontalSpacing = resources.getDimensionPixelSize(R.dimen.usb_table_horizontal_spacing)
+        val halfHorizontalSpacing = (horizontalSpacing / 2f).roundToInt().coerceAtLeast(0)
+
+        applyHorizontalSpacingToHeader(table, halfHorizontalSpacing)
         for (summary in folders) {
             val row = TableRow(this).apply {
                 isClickable = true
@@ -80,7 +84,9 @@ class UsbFileListActivity : AppCompatActivity() {
                 setOnClickListener { launchWriteActivity(summary.name) }
             }
             val artView = ImageView(this).apply {
-                layoutParams = TableRow.LayoutParams(albumArtSize, albumArtSize)
+                layoutParams = TableRow.LayoutParams(albumArtSize, albumArtSize).apply {
+                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
+                }
                 adjustViewBounds = true
                 scaleType = ImageView.ScaleType.CENTER_CROP
                 val artBytes = summary.albumArt
@@ -95,15 +101,19 @@ class UsbFileListActivity : AppCompatActivity() {
                 layoutParams = TableRow.LayoutParams(
                     TableRow.LayoutParams.WRAP_CONTENT,
                     TableRow.LayoutParams.WRAP_CONTENT
-                )
+                ).apply { setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0) }
             }
             val artistView = TextView(this).apply {
                 text = summary.artist ?: getString(R.string.usb_list_unknown_artist)
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f).apply {
+                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
+                }
             }
             val albumView = TextView(this).apply {
                 text = summary.album ?: getString(R.string.usb_list_unknown_album)
-                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+                layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f).apply {
+                    setMargins(halfHorizontalSpacing, 0, halfHorizontalSpacing, 0)
+                }
             }
             row.addView(nameView)
             row.addView(artView)
@@ -117,6 +127,21 @@ class UsbFileListActivity : AppCompatActivity() {
                 setMargins(0, verticalSpacing, 0, verticalSpacing)
             }
             table.addView(row, rowLayoutParams)
+        }
+    }
+
+    private fun applyHorizontalSpacingToHeader(table: TableLayout, halfSpacing: Int) {
+        val headerRow = table.getChildAt(0) as? TableRow ?: return
+        for (i in 0 until headerRow.childCount) {
+            val child = headerRow.getChildAt(i)
+            val existingParams = child.layoutParams
+            val params = if (existingParams is TableRow.LayoutParams) {
+                existingParams
+            } else {
+                TableRow.LayoutParams(existingParams)
+            }
+            params.setMargins(halfSpacing, params.topMargin, halfSpacing, params.bottomMargin)
+            child.layoutParams = params
         }
     }
 

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbFolderCache.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbFolderCache.kt
@@ -1,0 +1,60 @@
+package de.mw136.tonuino.ui
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.storage.StorageManager
+import android.provider.DocumentsContract
+import java.util.Locale
+
+/**
+ * In-memory cache of folder summaries for a single removable USB volume.
+ * Lives for the process lifetime and is cleared when the drive is detached.
+ */
+object UsbFolderCache {
+    private var cached: CacheEntry? = null
+
+    fun getCachedFolders(context: Context, uri: Uri): List<FolderSummary>? {
+        val treeId = uriTreeId(uri) ?: return null
+        if (!isRemovableVolume(context, treeId)) return null
+
+        val entry = cached
+        return if (entry != null && entry.treeId == treeId) entry.folders else null
+    }
+
+    fun save(context: Context, uri: Uri, folders: List<FolderSummary>) {
+        val treeId = uriTreeId(uri) ?: return
+        if (!isRemovableVolume(context, treeId)) return
+
+        cached = CacheEntry(treeId, folders)
+    }
+
+    fun clear() {
+        cached = null
+    }
+
+    private fun uriTreeId(uri: Uri): String? = try {
+        DocumentsContract.getTreeDocumentId(uri)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+    private fun isRemovableVolume(context: Context, treeId: String): Boolean {
+        val volumeId = treeId.substringBefore(":")
+        val storageManager = context.getSystemService(StorageManager::class.java)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && storageManager != null) {
+            val volume = storageManager.storageVolumes.firstOrNull { volume ->
+                val idMatches = volume.uuid == volumeId || (volumeId == "primary" && volume.isPrimary)
+                idMatches
+            }
+            if (volume != null) {
+                return volume.isRemovable
+            }
+        }
+
+        return volumeId.lowercase(Locale.ROOT) != "primary"
+    }
+
+    private data class CacheEntry(val treeId: String, val folders: List<FolderSummary>)
+}

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbPermissionStore.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbPermissionStore.kt
@@ -1,0 +1,53 @@
+package de.mw136.tonuino.ui
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.documentfile.provider.DocumentFile
+
+/**
+ * Remembers the last USB document tree URI and validates that we still hold a persisted permission.
+ */
+class UsbPermissionStore(private val context: Context) {
+    private val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+
+    fun rememberUri(uri: Uri) {
+        prefs.edit().putString(KEY_URI, uri.toString()).apply()
+    }
+
+    fun hasSavedUri(): Boolean = prefs.contains(KEY_URI)
+
+    fun getPersistedUriIfReadable(contentResolver: ContentResolver): Uri? {
+        val raw = prefs.getString(KEY_URI, null) ?: return null
+        val uri = Uri.parse(raw)
+
+        val permission = contentResolver.persistedUriPermissions.firstOrNull {
+            it.uri == uri && it.isReadPermission
+        }
+        if (permission == null) {
+            Log.i(TAG, "Persisted permission for $uri not found; clearing saved URI")
+            clear()
+            return null
+        }
+
+        val doc = DocumentFile.fromTreeUri(context, uri)
+        if (doc == null || !doc.canRead()) {
+            Log.i(TAG, "Saved USB location $uri is not readable anymore; clearing saved URI")
+            clear()
+            return null
+        }
+
+        return uri
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_URI).apply()
+    }
+
+    private companion object {
+        const val PREF_NAME = "usb_permissions"
+        const val KEY_URI = "last_usb_uri"
+        const val TAG = "UsbPermissionStore"
+    }
+}

--- a/app/src/main/java/de/mw136/tonuino/ui/UsbPermissionStore.kt
+++ b/app/src/main/java/de/mw136/tonuino/ui/UsbPermissionStore.kt
@@ -33,8 +33,7 @@ class UsbPermissionStore(private val context: Context) {
 
         val doc = DocumentFile.fromTreeUri(context, uri)
         if (doc == null || !doc.canRead()) {
-            Log.i(TAG, "Saved USB location $uri is not readable anymore; clearing saved URI")
-            clear()
+            Log.i(TAG, "Saved USB location $uri is not readable right now")
             return null
         }
 

--- a/app/src/main/res/drawable/ic_chevron_right_24.xml
+++ b/app/src/main/res/drawable/ic_chevron_right_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9.29,6.71L13.58,11l-4.29,4.29a1,1 0 1,0 1.42,1.42l5,-5a1,1 0 0,0 0,-1.42l-5,-5a1,1 0 1,0 -1.42,1.42z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -105,6 +105,35 @@
                     android:layout_height="wrap_content"
                     android:onClick="showBulkWriteActivity"
                     android:text="@string/main_write_bulk_button" />
+
+            <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/margin_default" />
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/main_usb_headline"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4" />
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/main_usb_description" />
+
+            <Button
+                    android:id="@+id/usb_list_button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:onClick="listUsbFiles"
+                    android:text="@string/main_usb_button" />
+
+            <TextView
+                    android:id="@+id/usb_result_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_half"
+                    android:textIsSelectable="true" />
         </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -121,12 +121,28 @@
                     android:layout_height="wrap_content"
                     android:text="@string/main_usb_description" />
 
-            <Button
-                    android:id="@+id/usb_list_button"
+            <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:onClick="listUsbFiles"
-                    android:text="@string/main_usb_button" />
+                    android:orientation="horizontal">
+
+                <Button
+                        android:id="@+id/usb_list_button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:onClick="listUsbFiles"
+                        android:text="@string/main_usb_button" />
+
+                <Button
+                        android:id="@+id/usb_list_pick_other_button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_half"
+                        android:layout_weight="1"
+                        android:onClick="pickUsbLocation"
+                        android:text="@string/main_usb_pick_other_button" />
+            </LinearLayout>
 
             <TextView
                     android:id="@+id/usb_result_text"

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -43,6 +43,9 @@
                     android:layout_weight="1"
                     android:text="@string/usb_list_header_album"
                     android:textStyle="bold" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
             </TableRow>
 
         </TableLayout>

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -4,9 +4,39 @@
     android:layout_height="match_parent"
     android:padding="@dimen/margin_default">
 
-    <TextView
-        android:id="@+id/usb_file_list_text"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textIsSelectable="true" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/usb_file_list_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <TableLayout
+            android:id="@+id/usb_file_table"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stretchColumns="1">
+
+            <TableRow>
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/usb_list_header_folder"
+                    android:textStyle="bold" />
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/usb_list_header_files"
+                    android:textAlignment="textEnd"
+                    android:textStyle="bold" />
+            </TableRow>
+
+        </TableLayout>
+
+    </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -1,54 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:padding="@dimen/margin_default">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/usb_file_list_status"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="wrap_content" />
 
-        <TextView
-            android:id="@+id/usb_file_list_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+    <ListView
+        android:id="@+id/usb_folder_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="@dimen/usb_list_divider_height"
+        android:visibility="gone" />
 
-        <TableLayout
-            android:id="@+id/usb_file_table"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:stretchColumns="2,3">
-
-            <TableRow>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/usb_list_header_folder"
-                    android:textStyle="bold" />
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/usb_list_header_album_art"
-                    android:textStyle="bold" />
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/usb_list_header_artist"
-                    android:textStyle="bold" />
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/usb_list_header_album"
-                    android:textStyle="bold" />
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-            </TableRow>
-
-        </TableLayout>
-
-    </LinearLayout>
-</ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -18,7 +18,7 @@
             android:id="@+id/usb_file_table"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="1">
+            android:stretchColumns="*">
 
             <TableRow>
                 <TextView
@@ -33,6 +33,18 @@
                     android:layout_weight="1"
                     android:text="@string/usb_list_header_files"
                     android:textAlignment="textEnd"
+                    android:textStyle="bold" />
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/usb_list_header_artist"
+                    android:textStyle="bold" />
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/usb_list_header_album"
                     android:textStyle="bold" />
             </TableRow>
 

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -18,9 +18,14 @@
             android:id="@+id/usb_file_table"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="1,2">
+            android:stretchColumns="2,3">
 
             <TableRow>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/usb_list_header_album_art"
+                    android:textStyle="bold" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -18,21 +18,13 @@
             android:id="@+id/usb_file_table"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:stretchColumns="*">
+            android:stretchColumns="1,2">
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="@string/usb_list_header_folder"
-                    android:textStyle="bold" />
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/usb_list_header_files"
-                    android:textAlignment="textEnd"
                     android:textStyle="bold" />
                 <TextView
                     android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -24,12 +24,12 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/usb_list_header_album_art"
+                    android:text="@string/usb_list_header_folder"
                     android:textStyle="bold" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/usb_list_header_folder"
+                    android:text="@string/usb_list_header_album_art"
                     android:textStyle="bold" />
                 <TextView
                     android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_usb_file_list.xml
+++ b/app/src/main/res/layout/activity_usb_file_list.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/margin_default">
+
+    <TextView
+        android:id="@+id/usb_file_list_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textIsSelectable="true" />
+</ScrollView>

--- a/app/src/main/res/layout/dialog_usb_scan_progress.xml
+++ b/app/src/main/res/layout/dialog_usb_scan_progress.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/margin_default">
+
+    <TextView
+        android:id="@+id/usb_scan_progress_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/usb_scan_preparing" />
+
+    <ProgressBar
+        android:id="@+id/usb_scan_progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/list_item_usb_folder.xml
+++ b/app/src/main/res/layout/list_item_usb_folder.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="@dimen/usb_album_art_size"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/usb_table_horizontal_spacing"
+    android:paddingEnd="@dimen/usb_table_horizontal_spacing"
+    android:paddingTop="@dimen/usb_list_item_vertical_padding"
+    android:paddingBottom="@dimen/usb_list_item_vertical_padding">
+
+    <ImageView
+        android:id="@+id/usb_folder_album_art"
+        android:layout_width="@dimen/usb_album_art_size"
+        android:layout_height="@dimen/usb_album_art_size"
+        android:layout_marginEnd="@dimen/usb_table_horizontal_spacing"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/usb_list_header_album_art"
+        android:scaleType="centerCrop" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/usb_folder_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceListItem"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/usb_folder_artist"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:textColorSecondary" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/usb_folder_chevron"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/usb_table_horizontal_spacing"
+        android:contentDescription="@string/usb_list_row_action_hint"
+        android:src="@drawable/ic_chevron_right_24" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/list_item_usb_folder.xml
+++ b/app/src/main/res/layout/list_item_usb_folder.xml
@@ -39,6 +39,13 @@
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="?android:textColorSecondary" />
+
+        <TextView
+            android:id="@+id/usb_folder_track_count"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:textColorSecondary" />
     </LinearLayout>
 
     <ImageView

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,4 +7,5 @@
     <dimen name="appbar_padding">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
+    <dimen name="usb_album_art_size">48dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,4 +8,5 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
     <dimen name="usb_album_art_size">48dp</dimen>
+    <dimen name="usb_table_horizontal_spacing">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,6 @@
     <dimen name="appbar_padding_top">8dp</dimen>
     <dimen name="usb_album_art_size">48dp</dimen>
     <dimen name="usb_table_horizontal_spacing">10dp</dimen>
+    <dimen name="usb_list_item_vertical_padding">10dp</dimen>
+    <dimen name="usb_list_divider_height">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="usb_scan_preparing">Preparing scan...</string>
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>
     <string name="usb_list_row_action_hint">Write tag with this folder</string>
+    <string name="usb_list_track_count">%1$d tracks</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>
     <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>
     <string name="main_usb_new_drive_use">Use new drive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>
     <string name="usb_list_row_action_hint">Write tag with this folder</string>
     <string name="usb_list_track_count">%1$d tracks</string>
+    <string name="usb_list_empty_folder">(empty)</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>
     <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>
     <string name="main_usb_new_drive_use">Use new drive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="main_usb_picker_cancelled">Selection was cancelled. No files read.</string>
     <string name="main_usb_missing_uri">No location was returned by the system.</string>
     <string name="main_usb_open_failed">Could not open the selected storage.</string>
+    <string name="main_usb_using_saved_access">Reusing saved USB access...</string>
+    <string name="main_usb_saved_access_invalid">Saved USB access is no longer valid. Please reselect the drive.</string>
     <string name="main_usb_no_files">No files found on the selected drive.</string>
     <string name="main_usb_listing_prefix">Files on USB drive:</string>
     <string name="usb_list_title">USB files</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="usb_list_loading">Loading files...</string>
     <string name="usb_list_no_uri">No USB location was provided.</string>
     <string name="usb_list_error">Could not open the selected storage.</string>
-    <string name="usb_list_header_folder">Folder</string>
+    <string name="usb_list_header_folder">#</string>
     <string name="usb_list_header_files">Files</string>
     <string name="usb_list_header_artist">Artist</string>
     <string name="usb_list_header_album">Album</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="usb_folder_unknown_name">(unnamed folder)</string>
     <string name="usb_list_unknown_artist">(unknown artist)</string>
     <string name="usb_list_unknown_album">(unknown album)</string>
+    <string name="main_usb_new_drive_title">New USB drive detected</string>
+    <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>
+    <string name="main_usb_new_drive_use">Use new drive</string>
+    <string name="main_usb_new_drive_keep">Keep saved location</string>
 
 
     <!-- Strings used on EditActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="usb_scan_dialog_title">Scanning files</string>
     <string name="usb_scan_preparing">Preparing scan...</string>
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>
+    <string name="usb_list_row_action_hint">Write tag with this folder</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>
     <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>
     <string name="main_usb_new_drive_use">Use new drive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,8 +37,12 @@
     <string name="usb_list_error">Could not open the selected storage.</string>
     <string name="usb_list_header_folder">Folder</string>
     <string name="usb_list_header_files">Files</string>
+    <string name="usb_list_header_artist">Artist</string>
+    <string name="usb_list_header_album">Album</string>
     <string name="usb_list_no_folders">No folders found on the selected drive.</string>
     <string name="usb_folder_unknown_name">(unnamed folder)</string>
+    <string name="usb_list_unknown_artist">(unknown artist)</string>
+    <string name="usb_list_unknown_album">(unknown album)</string>
 
 
     <!-- Strings used on EditActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,10 @@
     <string name="usb_list_loading">Loading files...</string>
     <string name="usb_list_no_uri">No USB location was provided.</string>
     <string name="usb_list_error">Could not open the selected storage.</string>
+    <string name="usb_list_header_folder">Folder</string>
+    <string name="usb_list_header_files">Files</string>
+    <string name="usb_list_no_folders">No folders found on the selected drive.</string>
+    <string name="usb_folder_unknown_name">(unnamed folder)</string>
 
 
     <!-- Strings used on EditActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,10 @@
     <string name="main_usb_open_failed">Could not open the selected storage.</string>
     <string name="main_usb_no_files">No files found on the selected drive.</string>
     <string name="main_usb_listing_prefix">Files on USB drive:</string>
+    <string name="usb_list_title">USB files</string>
+    <string name="usb_list_loading">Loading files...</string>
+    <string name="usb_list_no_uri">No USB location was provided.</string>
+    <string name="usb_list_error">Could not open the selected storage.</string>
 
 
     <!-- Strings used on EditActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>
     <string name="usb_list_row_action_hint">Write tag with this folder</string>
     <string name="usb_list_track_count">%1$d tracks</string>
+    <string name="usb_list_track_count_with_duration">%1$d tracks, %2$s</string>
     <string name="usb_list_mixed_album">(mixed)</string>
     <string name="usb_list_empty_folder">(empty)</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>
     <string name="usb_list_row_action_hint">Write tag with this folder</string>
     <string name="usb_list_track_count">%1$d tracks</string>
+    <string name="usb_list_mixed_album">(mixed)</string>
     <string name="usb_list_empty_folder">(empty)</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>
     <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="main_usb_headline">USB storage</string>
     <string name="main_usb_description">Connect a USB thumb drive or SD card reader and let the app list its files.</string>
     <string name="main_usb_button">List files on USB drive</string>
+    <string name="main_usb_pick_other_button">Choose different location</string>
     <string name="main_usb_not_found">No removable storage detected. Connect a USB drive or card reader or pick a location manually.</string>
     <string name="main_usb_picker_cancelled">Selection was cancelled. No files read.</string>
     <string name="main_usb_missing_uri">No location was returned by the system.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="main_usb_open_failed">Could not open the selected storage.</string>
     <string name="main_usb_using_saved_access">Reusing saved USB access...</string>
     <string name="main_usb_saved_access_invalid">Saved USB access is no longer valid. Please reselect the drive.</string>
+    <string name="main_usb_no_saved_location">No USB location saved yet. Choose a location first.</string>
     <string name="main_usb_no_files">No files found on the selected drive.</string>
     <string name="main_usb_listing_prefix">Files on USB drive:</string>
     <string name="usb_list_title">USB files</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,9 +23,9 @@
     <string name="main_write_tag_button">Write data on tag</string>
     <string name="main_write_bulk_button">Enter bulk write list</string>
     <string name="main_usb_headline">USB storage</string>
-    <string name="main_usb_description">Connect a USB thumb drive or SD card reader and let the app list its files.</string>
-    <string name="main_usb_button">List files on USB drive</string>
-    <string name="main_usb_pick_other_button">Choose different location</string>
+    <string name="main_usb_description">Connect your Tonuino microSD via a USB card reader (or via the builtin USB of the DFPlayer Mini) to write tags. It will scan the content of the microSD card giving you an overview of the content of each folder. Tapping on a folder lets you directly write a new tag for it.</string>
+    <string name="main_usb_button">Show folders</string>
+    <string name="main_usb_pick_other_button">Select location</string>
     <string name="main_usb_not_found">No removable storage detected. Connect a USB drive or card reader or pick a location manually.</string>
     <string name="main_usb_picker_cancelled">Selection was cancelled. No files read.</string>
     <string name="main_usb_missing_uri">No location was returned by the system.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,15 @@
     <string name="main_write_tag_description">Existing data on the tag will be overwritten.</string>
     <string name="main_write_tag_button">Write data on tag</string>
     <string name="main_write_bulk_button">Enter bulk write list</string>
+    <string name="main_usb_headline">USB storage</string>
+    <string name="main_usb_description">Connect a USB thumb drive or SD card reader and let the app list its files.</string>
+    <string name="main_usb_button">List files on USB drive</string>
+    <string name="main_usb_not_found">No removable storage detected. Connect a USB drive or card reader or pick a location manually.</string>
+    <string name="main_usb_picker_cancelled">Selection was cancelled. No files read.</string>
+    <string name="main_usb_missing_uri">No location was returned by the system.</string>
+    <string name="main_usb_open_failed">Could not open the selected storage.</string>
+    <string name="main_usb_no_files">No files found on the selected drive.</string>
+    <string name="main_usb_listing_prefix">Files on USB drive:</string>
 
 
     <!-- Strings used on EditActivity -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="usb_list_loading">Loading files...</string>
     <string name="usb_list_no_uri">No USB location was provided.</string>
     <string name="usb_list_error">Could not open the selected storage.</string>
+    <string name="usb_list_header_album_art">Art</string>
     <string name="usb_list_header_folder">#</string>
     <string name="usb_list_header_files">Files</string>
     <string name="usb_list_header_artist">Artist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,9 @@
     <string name="usb_folder_unknown_name">(unnamed folder)</string>
     <string name="usb_list_unknown_artist">(unknown artist)</string>
     <string name="usb_list_unknown_album">(unknown album)</string>
+    <string name="usb_scan_dialog_title">Scanning files</string>
+    <string name="usb_scan_preparing">Preparing scan...</string>
+    <string name="usb_scan_progress">%1$d / %2$d files processed</string>
     <string name="main_usb_new_drive_title">New USB drive detected</string>
     <string name="main_usb_new_drive_message">Use the newly connected drive instead of the saved location?</string>
     <string name="main_usb_new_drive_use">Use new drive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="usb_folder_unknown_name">(unnamed folder)</string>
     <string name="usb_list_unknown_artist">(unknown artist)</string>
     <string name="usb_list_unknown_album">(unknown album)</string>
+    <string name="usb_folder_title_format">%1$s: %2$s</string>
     <string name="usb_scan_dialog_title">Scanning files</string>
     <string name="usb_scan_preparing">Preparing scan...</string>
     <string name="usb_scan_progress">%1$d / %2$d files processed</string>


### PR DESCRIPTION
Hi @marc123!

First of all thanks for this nice app! I'm currently building my very first Tonuino box and your app appears like a big step up in user experience for writing NFC tags compared to the builtin flow via the Tonuino box itself. However, I think we can improve it even more! I briefly searched the forums and I read about workflows where people are juggling with CSV files or scanning QR codes. 
IMO, the process can be even smoother, especially when the USB connection of the DFPlayer Mini is exposed to the outside of the box. It behaves just as a regular USB-connected SD card reader, i.e. the microSD card shows up as an external storage device.

So here comes my PR which is rather a first hack at how I believe we can leverage our Android phones to improve the process. When you attach your Tonuino via USB, the app can now scan the content of the microSD card, extract metadata like album art, album, artist and so on so you get a nice overview of the folder structure. This makes it really easy to select the folder you want to program a tag for.

It's already working and bascially scratching my own itch. I have to admit that all of it has been written by AI as I am not an Anroid/ Kotlin programmer. But please bear with me, here's a demo screencast:


https://github.com/user-attachments/assets/54b8b4b7-faf1-4ee6-bb79-8424bfa633c8



So basically the question is: would you be interested to integrate this into the app?
